### PR TITLE
Suggested updated to #1407

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1409,7 +1409,7 @@ class CompositeUnit(UnitBase):
         of the base units.
     """
     def __init__(self, scale, bases, powers):
-        if scale == 1.:
+        if scale == 1. or is_effectively_unity(scale):
             scale = 1
         self._scale = scale
         for base in bases:
@@ -1491,6 +1491,10 @@ class CompositeUnit(UnitBase):
 
         self._bases = [x[0] for x in new_parts]
         self._powers = [x[1] for x in new_parts]
+
+        if is_effectively_unity(scale):
+            scale = 1
+
         self._scale = scale
 
     def __copy__(self):
@@ -1541,7 +1545,7 @@ class CompositeUnit(UnitBase):
 
     def is_unity(self):
         unit = self.decompose()
-        return len(unit.bases) == 0 and is_effectively_unity(unit.scale)
+        return len(unit.bases) == 0 and unit.scale == 1
 
 
 si_prefixes = [

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -12,7 +12,6 @@ import os
 import re
 
 from .base import Base
-from ..utils import is_effectively_unity
 from . import utils
 
 
@@ -319,7 +318,7 @@ class CDS(Base):
         unit = utils.decompose_to_known_units(unit, self._get_unit_name)
 
         if isinstance(unit, core.CompositeUnit):
-            if is_effectively_unity(unit.scale):
+            if unit.scale == 1:
                 s = ''
             else:
                 m, e = utils.split_mantissa_exponent(unit.scale)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -10,7 +10,6 @@ from __future__ import (absolute_import, division, print_function,
 
 from . import base
 from . import utils
-from ..utils import is_effectively_unity
 
 
 class Console(base.Base):
@@ -67,7 +66,7 @@ class Console(base.Base):
         from .. import core
 
         if isinstance(unit, core.CompositeUnit):
-            if is_effectively_unity(unit.scale):
+            if unit.scale == 1:
                 s = ''
             else:
                 s = self._format_exponential_notation(unit.scale)

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -10,7 +10,6 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 from . import generic
-from ..utils import is_effectively_unity
 from . import utils
 
 
@@ -108,7 +107,7 @@ class Fits(generic.Generic):
         unit = utils.decompose_to_known_units(unit, self._get_unit_name)
 
         if isinstance(unit, core.CompositeUnit):
-            if not is_effectively_unity(unit.scale):
+            if unit.scale != 1:
                 raise ValueError(
                     "The FITS unit format is not able to represent scale. "
                     "Multiply your data by {0:e}.".format(unit.scale))

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -12,7 +12,6 @@ import re
 
 from . import utils
 from .base import Base
-from ..utils import is_effectively_unity
 
 
 class Generic(Base):
@@ -383,7 +382,7 @@ class Generic(Base):
         if isinstance(unit, core.CompositeUnit):
             parts = []
 
-            if self._show_scale and not is_effectively_unity(unit.scale):
+            if self._show_scale and unit.scale != 1:
                 parts.append('{0:g}'.format(unit.scale))
 
             if len(unit.bases):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -9,7 +9,6 @@ from __future__ import (absolute_import, division, print_function,
 
 from . import base
 from . import utils
-from ..utils import is_effectively_unity
 
 
 class Latex(base.Base):
@@ -66,7 +65,7 @@ class Latex(base.Base):
         if latex_name is not None:
             s = latex_name
         elif isinstance(unit, core.CompositeUnit):
-            if is_effectively_unity(unit.scale):
+            if unit.scale == 1:
                 s = ''
             else:
                 s = self._format_exponential_notation(unit.scale) + r'\,'

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 from . import generic
-from ..utils import is_effectively_unity
 from . import utils
 
 
@@ -102,7 +101,7 @@ class VOUnit(generic.Generic):
 
         if isinstance(unit, core.CompositeUnit):
             s = ''
-            if not is_effectively_unity(unit.scale):
+            if unit.scale != 1:
                 m, ex = utils.split_mantissa_exponent(unit.scale)
                 if m:
                     s += m + ' '


### PR DESCRIPTION
Only apply the is_effectively_unity check when assigning the ._scale int...ernal attribute, making it unncessary to use whenever comparing .scale to 1.  This still places onus developers of the units package to remember this check whenever updating ._scale, but that's less trouble than the current case.
