### PR TITLE
Add __unicode__ to Unit and Angle so that unicode(unit/angle) works as expected

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -486,6 +486,13 @@ class Angle(u.Quantity):
     def _repr_latex_(self):
         return str(self.to_string(format='latex'))
 
+    def __unicode__(self):
+        self_string = self.to_string(format='unicode')
+        if isinstance(self_string, np.ndarray):
+            return u"[{}]".format(u" ".join(s for s in self_string))
+        else:
+            return self_string
+
 
 class Latitude(Angle):
     """

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
+# -*- coding: utf-8 -*-
 # Test initalization of angles not already covered by the API tests
 
 import numpy as np
@@ -107,6 +107,14 @@ def test_angle_repr():
 
     a = Angle(0, u.deg)
     repr(a)
+
+
+def test_angle_unicode():
+    a = Angle(['120d','121d','122d'])
+    assert(unicode(a) ==
+           u'[120°00′00.00000″ 121°00′00.00000″ 122°00′00.00000″]')
+    a = Angle('3h4m5s')
+    assert unicode(a) == u'3ʰ04ᵐ05.00000ˢ'
 
 
 def test_wrap_at_inplace():

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -205,6 +205,10 @@ class UnitBase(object):
         """Return string representation for unit"""
         return unit_format.Generic().to_string(self)
 
+    def __unicode__(self):
+        """Return unicode formatted string representation for unit"""
+        return unit_format.Unicode().to_string(self)
+
     def __repr__(self):
         return 'Unit("' + str(self) + '")'
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -69,6 +69,10 @@ def test_repr():
     assert repr(u.cm) == 'Unit("cm")'
 
 
+def test_unicode():
+    assert unicode(u.m / u.s) == u' m\n \u2500\n s'
+
+
 def test_units_conversion():
     assert_allclose(u.kpc.to(u.Mpc), 0.001)
     assert_allclose(u.Mpc.to(u.kpc), 1000)


### PR DESCRIPTION
Inspired by formatting-related PRs such as #1322 and #1434, a trivial further one, to implement `__unicode__`, which get called when someone does `unicode(something)`, for `Unit` and `Angle`. With this 

```
print unicode(u.m/u.s)
 m
 ─
 s
```

and

```
print unicode(Angle(['1h2m3s','4h5m6s'])), unicode(Angle('1d2m3s'))
[1ʰ02ᵐ03.00000ˢ 4ʰ05ᵐ06.00000ˢ] 1°02′03.00000″
```

Here, `unicode(a)` is slightly different from `a.to_string(format='unicode')` in that, like `str(a)` it returns a string containing all array elements, rather than an array of (unicode) strings.
