### PR TITLE
Put back in automatic unit selector for distmod with array support

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -49,7 +49,8 @@ class Distance(u.Quantity):
         If `None`, the current cosmology will be used (see
         `astropy.cosmology` for details).
     distmod : float or `~astropy.units.Quantity`
-        The distance modulus for this distance.
+        The distance modulus for this distance. Note that if ``unit`` is not
+        provided, a guess will be made at the unit between AU, pc, kpc, and Mpc.
     dtype : `~numpy.dtype`, optional
         See `~astropy.units.Quantity`.
     copy : bool, optional
@@ -121,6 +122,19 @@ class Distance(u.Quantity):
                                      'or `distmod` in Distance constructor.')
 
                 value = cls._distmod_to_pc(distmod)
+                if unit is None:
+                    # if the unit is not specified, guess based on the mean of
+                    # the log of the distance
+                    meanlogval = np.log10(value.value).mean()
+                    if meanlogval > 6:
+                        unit = u.Mpc
+                    elif meanlogval > 3:
+                        unit = u.kpc
+                    elif meanlogval < -3: #~200 AU
+                        unit = u.AU
+                    else:
+                        unit = u.pc
+
                 # Continue on to take account of unit and other arguments
                 # but a copy is already made, so no longer necessary
                 copy = False

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -195,6 +195,16 @@ def test_distmod():
     with pytest.raises(ValueError):
         d = Distance(z=.23, distmod=20)
 
+    #check the Mpc/kpc/pc behavior
+    assert Distance(distmod=1).unit == u.pc
+    assert Distance(distmod=11).unit == u.kpc
+    assert Distance(distmod=26).unit == u.Mpc
+    assert Distance(distmod=-21).unit == u.AU
+
+    #if an array, uses the mean of the log of the distances
+    assert Distance(distmod=[1, 11, 26]).unit == u.kpc
+
+
 
 def test_distance_in_coordinates():
     """


### PR DESCRIPTION
Just as it says.  This now uses the mean of the log of all the values, which is a reasonable heuristic for what a human might do to try to generally get small numbers but typically-used units.
