### PR TITLE
added whatsnew section about the posvel->representation stuff

### DIFF
--- a/docs/whatsnew/1.3.rst
+++ b/docs/whatsnew/1.3.rst
@@ -1,0 +1,44 @@
+.. doctest-skip-all
+
+.. _whatsnew-1.3:
+
+==========================
+What's New in Astropy 1.3?
+==========================
+
+Overview
+--------
+
+Astropy 1.3 is a major release that adds significant new functionality since
+the 1.2.x series of releases.
+
+In particular, this release includes:
+
+*
+
+In addition to these major changes, Astropy 1.3 includes a large number of
+smaller improvements and bug fixes, which are described in the
+:ref:`changelog`. By the numbers:
+
+* xxx issues have been closed since v1.2
+* xxx pull requests have been merged since v1.2
+* xxx distinct people have contributed code
+
+Other significant changes
+-------------------------
+
+The `astropy.coordinates.GCRS` and `astropy.coordinates.PrecessedGeocentric`
+frames have been subtly changed such that their ``obsgeoloc`` and ``obsgeovel``
+attributes return ``CartesianRepresentation`` objects, rather than ``Quantity``
+objects.  This was judged to be an advanced enough use case that this change
+will not include a deprecation period (as this would have added substantial
+complexity to `astropy.coordinates`). To make code written for earlier versions
+compatible with v1.3 and up, simply change all instances of
+``<object>.obsgeoloc`` or ``<object>.obsgeovel`` to
+``<object>.obsgeoloc.xyz``/``<object>.obsgeovel.xyz``.
+
+Full change log
+---------------
+
+To see a detailed list of all changes in version v1.2, including changes in
+API, please see the :ref:`changelog`.

--- a/docs/whatsnew/index.rst
+++ b/docs/whatsnew/index.rst
@@ -5,6 +5,7 @@ Major Release History
 .. toctree::
    :maxdepth: 1
 
+   1.3
    1.2
    1.1
    1.0


### PR DESCRIPTION
As I mentioned in https://github.com/astropy/astropy/pull/5253#issuecomment-243269387, this just adds a bit more on the changes in that PR and how to work around them.

(Note it also adds a what's new section for 1.3, so this assumes astropy/astropy#5253 is for v1.3 ... which is inconsitent with the changelog but best to discuss that in #5253 proper)
