### PR TITLE
pytest 3 settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
 env:
     global:
         # Set defaults to avoid repeating in most cases
+        - ASTROPY_USE_SYSTEM_PYTEST=1
         - PYTHON_VERSION=3.5
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@
 environment:
 
     global:
+        ASTROPY_USE_SYSTEM_PYTEST: 1
         PYTHON: "C:\\conda"
         MINICONDA_VERSION: "latest"
         CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -14,3 +14,6 @@ else:
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
+
+# To avoid warnings in pytest 3.x
+collect_ignore = ['astropy/tests/runner.py']


### PR DESCRIPTION
This forces Appveyor and Travis to use system pytest, which presumably will be pytest 3 (untested). Also fixes [pytest warnings that I reported](https://github.com/astropy/astropy/pull/5688#issuecomment-272186943).

NOTE: Not sure how to enforce pytest 3 in CircleCI but I don't really care about that one.