### PR TITLE
More pytest 3 additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='pytest>=3'
         - SETUP_XVFB=True
         - SPHINX_VERSION='<1.5'
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -14,6 +14,3 @@ else:
 enable_deprecations_as_exceptions(include_astropy_deprecations=False)
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
-
-# To avoid warnings in pytest 3.x
-collect_ignore = ['astropy/tests/runner.py']

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,9 +1,11 @@
-from astropy.tests.runner import TestRunner, TestRunnerBase, keyword
+from astropy.tests.runner import TestRunner as T_Runner
+from astropy.tests.runner import TestRunnerBase as T_RunnerBase
+from astropy.tests.runner import keyword
 from astropy.tests.helper import pytest
 
 
 def test_disable_kwarg():
-    class no_remote_data(TestRunner):
+    class no_remote_data(T_Runner):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
@@ -14,13 +16,13 @@ def test_disable_kwarg():
 
 
 def test_wrong_kwarg():
-    r = TestRunner('.')
+    r = T_Runner('.')
     with pytest.raises(TypeError):
         r.run_tests(spam='eggs')
 
 
 def test_invalid_kwarg():
-    class bad_return(TestRunnerBase):
+    class bad_return(T_RunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return 'bob'
@@ -31,7 +33,7 @@ def test_invalid_kwarg():
 
 
 def test_new_kwarg():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -44,7 +46,7 @@ def test_new_kwarg():
 
 
 def test_priority():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -61,7 +63,7 @@ def test_priority():
 
 
 def test_docs():
-    class Spam(TestRunnerBase):
+    class Spam(T_RunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             """


### PR DESCRIPTION
Another attempt to rid of pytest warnings. Pin pytest version to 3.0.5 for Travis. This does *not* fix doctest failures in Python 2.

Tests are running at https://travis-ci.org/pllim/astropy so you don't have to merge this until they are done. 