### PR TITLE
Remove remaining deprecation warnings

### DIFF
--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,11 +1,15 @@
-from astropy.tests.runner import TestRunner as T_Runner
-from astropy.tests.runner import TestRunnerBase as T_RunnerBase
+# Renamed these imports so that them being in the namespace will not
+# cause pytest 3 to discover them as tests and then complain that
+# they have __init__ defined.
+from astropy.tests.runner import TestRunner as _TestRunner
+from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
+
 from astropy.tests.runner import keyword
 from astropy.tests.helper import pytest
 
 
 def test_disable_kwarg():
-    class no_remote_data(T_Runner):
+    class no_remote_data(_TestRunner):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
@@ -16,13 +20,13 @@ def test_disable_kwarg():
 
 
 def test_wrong_kwarg():
-    r = T_Runner('.')
+    r = _TestRunner('.')
     with pytest.raises(TypeError):
         r.run_tests(spam='eggs')
 
 
 def test_invalid_kwarg():
-    class bad_return(T_RunnerBase):
+    class bad_return(_TestRunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return 'bob'
@@ -33,7 +37,7 @@ def test_invalid_kwarg():
 
 
 def test_new_kwarg():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -46,7 +50,7 @@ def test_new_kwarg():
 
 
 def test_priority():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
@@ -63,7 +67,7 @@ def test_priority():
 
 
 def test_docs():
-    class Spam(T_RunnerBase):
+    class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             """

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.3.3
+[tool:pytest]
+minversion = 3
 norecursedirs = ".tox" "build" "docs[\/]_build" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 doctest_norecursedirs = "astropy[\/]sphinx"


### PR DESCRIPTION
This PR hopefully will address:

* This warning: `[pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.` (Re-implementation of some part of #5678 that is undone in #5697 because it broke doctest in bundled pytest 2.8.)
* @mhvk and @astrofrog's dislike of `T_Runner` imports. (p.s. If `_TestRunner` re-introduces those warnings I got rid of, can I import it as `BladeRunner`?)