### PR TITLE
Add d_xyz and move get_name()

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -94,8 +94,12 @@ class RepresentationBase(ShapedLikeNDArray):
         try:
             attrs = broadcast_arrays(*attrs, subok=True)
         except ValueError:
-            raise ValueError("Input parameters cannot be broadcast")
-
+            if len(components) <= 2:
+                c_str = ' and '.join(components)
+            else:
+                c_str = ', '.join(components[:2]) + ', and ' + components[2]
+            raise ValueError("Input parameters {0} cannot be broadcast"
+                             .format(c_str))
         for component, attr in zip(components, attrs):
             setattr(self, '_' + component, attr)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -18,14 +18,16 @@ import astropy.units as u
 from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..extern import six
-from ..utils import ShapedLikeNDArray, classproperty, sharedmethod
+from ..utils import ShapedLikeNDArray, classproperty
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
-# Note: Offset classes gets added to this at the end.
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
-           "PhysicsSphericalRepresentation", "CylindricalRepresentation"]
+           "PhysicsSphericalRepresentation", "CylindricalRepresentation",
+           "BaseOffset", "CartesianOffset", "SphericalOffset",
+           "UnitSphericalOffset", "PhysicsSphericalOffset",
+           "CylindricalOffset"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -284,7 +286,7 @@ class BaseRepresentation(RepresentationBase):
     recommended_units = {}  # subclasses can override
 
     def represent_as(self, other_class):
-        if other_class == self.__class__:
+        if other_class is self.__class__:
             return self
         else:
             # The default is to convert via cartesian coordinates
@@ -1508,6 +1510,29 @@ class BaseOffset(RepresentationBase):
         return cls(*(other.dot(e / base_sf[component])
                      for component, e in six.iteritems(base_e)))
 
+    def represent_as(self, other_class, base):
+        if other_class is self.__class__:
+            return self
+
+        # The default is to convert via cartesian coordinates.
+        self_cartesian = self.to_cartesian(base)
+        if issubclass(other_class, BaseOffset):
+            base = base.represent_as(other_class.base_representation)
+            return other_class.from_cartesian(self_cartesian, base)
+        else:
+            return other_class.from_cartesian(self_cartesian)
+
+    @classmethod
+    def from_representation(cls, representation, base):
+        cls._check_base(base)
+        if isinstance(representation, BaseOffset):
+            cartesian = representation.to_cartesian(
+                base.represent_as(representation.base_representation))
+        else:
+            cartesian = representation.to_cartesian()
+
+        return cls.from_cartesian(cartesian, base)
+
     def _scale_operation(self, op, *args):
         scaled_attrs = [op(getattr(self, c), *args) for c in self.components]
         return self.__class__(*scaled_attrs, copy=False)
@@ -1572,10 +1597,72 @@ class CartesianOffset(BaseOffset):
         return cls(*[getattr(other, c) for c in other.components])
 
 
-for r, r_cls in REPRESENTATION_CLASSES.items():
-    name = r_cls.__name__.replace('Representation', 'Offset')
-    if name not in locals():
-        locals()[name] = type(name, (BaseOffset,),
-                              {'base_representation': r_cls})
-    if name not in __all__:
-        __all__.append(name)
+class SphericalOffset(BaseOffset):
+    base_representation = SphericalRepresentation
+
+    def represent_as(self, other_class, base=None):
+        if issubclass(other_class, UnitSphericalOffset):
+            return other_class(self.d_lon, self.d_lat)
+        elif issubclass(other_class, PhysicsSphericalOffset):
+            return other_class(self.d_lon, -self.d_lat, self.d_distance)
+        else:
+            return super(SphericalOffset, self).represent_as(other_class, base)
+
+    @classmethod
+    def from_representation(cls, representation, base=None):
+        if isinstance(representation, PhysicsSphericalOffset):
+            return cls(representation.d_phi, -representation.d_theta,
+                       representation.d_r)
+        else:
+            return super(SphericalOffset,
+                         cls).from_representation(representation, base)
+
+
+class UnitSphericalOffset(BaseOffset):
+    base_representation = UnitSphericalRepresentation
+
+    def to_cartesian(self, base):
+        if isinstance(base, SphericalRepresentation):
+            scale = base.distance
+        elif isinstance(base, PhysicsSphericalRepresentation):
+            scale = base.r
+        else:
+            return super(UnitSphericalOffset, self).to_cartesian(base)
+
+        base = base.represent_as(UnitSphericalRepresentation)
+        return scale * super(UnitSphericalOffset, self).to_cartesian(base)
+
+    @classmethod
+    def from_representation(cls, representation, base=None):
+        if isinstance(representation, SphericalOffset):
+            return cls(representation.d_lon, representation.d_lat)
+        elif isinstance(representation, PhysicsSphericalOffset):
+            return cls(representation.d_phi, -representation.d_theta)
+        else:
+            return super(UnitSphericalOffset,
+                         cls).from_representation(representation, base)
+
+class PhysicsSphericalOffset(BaseOffset):
+    base_representation = PhysicsSphericalRepresentation
+
+    def represent_as(self, other_class, base=None):
+        if issubclass(other_class, SphericalOffset):
+            return other_class(self.d_phi, -self.d_theta, self.d_r)
+        elif issubclass(other_class, UnitSphericalOffset):
+            return other_class(self.d_phi, -self.d_theta)
+        else:
+            return super(PhysicsSphericalOffset,
+                         self).represent_as(other_class, base)
+
+    @classmethod
+    def from_representation(cls, representation, base=None):
+        if isinstance(representation, SphericalOffset):
+            return cls(representation.d_lon, -representation.d_lat,
+                       representation.d_distance)
+        else:
+            return super(PhysicsSphericalOffset,
+                         cls).from_representation(representation, base)
+
+
+class CylindricalOffset(BaseOffset):
+    base_representation = CylindricalRepresentation

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -153,7 +153,7 @@ class RepresentationBase(ShapedLikeNDArray):
 
     @abc.abstractmethod
     def _scale_operation(self, op, *args):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __mul__(self, other):
         return self._scale_operation(operator.mul, other)
@@ -176,7 +176,7 @@ class RepresentationBase(ShapedLikeNDArray):
 
     @abc.abstractmethod
     def _combine_operation(self, op, other, reverse=False):
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def __add__(self, other):
         return self._combine_operation(operator.add, other)
@@ -1469,11 +1469,11 @@ class BaseOffset(RepresentationBase):
             self.attr_classes[name] = type(attr)
             setattr(self, '_' + name, attr)
 
-    @sharedmethod
-    def _check_base(self, base):
-        if not isinstance(base, self.base_representation):
+    @classmethod
+    def _check_base(cls, base):
+        if not isinstance(base, cls.base_representation):
             raise TypeError('need a base of the correct representation type, '
-                            '{0}, not {1}.'.format(self.base_representation,
+                            '{0}, not {1}.'.format(cls.base_representation,
                                                    type(base)))
 
     def to_cartesian(self, base):
@@ -1493,8 +1493,8 @@ class BaseOffset(RepresentationBase):
                            base_sf[component] * e
                            for component, e in six.iteritems(base_e)))
 
-    @sharedmethod
-    def from_cartesian(self, other, base):
+    @classmethod
+    def from_cartesian(cls, other, base):
         """Interpret 3D rectangular cartesian coordinates as offsets.
 
         Parameters
@@ -1502,8 +1502,7 @@ class BaseOffset(RepresentationBase):
         base : instance of ``self.base_representation``
             Base relative to which the offsets are defined.
         """
-        cls = self if isinstance(self, type) else type(self)
-        self._check_base(base)
+        cls._check_base(base)
         base_e = base.unit_vectors()
         base_sf = base.scale_factors()
         return cls(*(other.dot(e / base_sf[component])
@@ -1514,12 +1513,17 @@ class BaseOffset(RepresentationBase):
         return self.__class__(*scaled_attrs, copy=False)
 
     def _combine_operation(self, op, other, reverse=False):
-        try:
-            self_cartesian = self.to_cartesian(other)
-        except TypeError:
-            return NotImplemented
+        if isinstance(self, type(other)):
+            first, second = (self, other) if not reverse else (other, self)
+            return self.__class__(*[op(getattr(first, c), getattr(second, c))
+                                    for c in self.components])
+        else:
+            try:
+                self_cartesian = self.to_cartesian(other)
+            except TypeError:
+                return NotImplemented
 
-        return other._combine_operation(op, self_cartesian, not reverse)
+            return other._combine_operation(op, self_cartesian, not reverse)
 
     def norm(self, base=None):
         """Vector norm.
@@ -1573,4 +1577,5 @@ for r, r_cls in REPRESENTATION_CLASSES.items():
     if name not in locals():
         locals()[name] = type(name, (BaseOffset,),
                               {'base_representation': r_cls})
+    if name not in __all__:
         __all__.append(name)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -62,6 +62,35 @@ def _array2string(values, prefix=''):
     return np.array2string(values, formatter=formatter, style=fmt,
                            separator=', ', prefix=prefix)
 
+def _combine_xyz(x, y, z, xyz_axis=0):
+    """
+    Combine the 3 input arrays, ``x``, ``y``, ``z``.
+    """
+
+    # Add new axis in x, y, z so one can concatenate them around it.
+    # NOTE: just use np.stack once our minimum numpy version is 1.10.
+    result_ndim = x.ndim + 1
+    if not -result_ndim <= xyz_axis < result_ndim:
+        raise IndexError('xyz_axis {0} out of bounds [-{1}, {1})'
+                         .format(xyz_axis, result_ndim))
+
+    if xyz_axis < 0:
+        xyz_axis += result_ndim
+
+    # Get x, y, z to the same units (this is very fast for identical units)
+    # since np.concatenate cannot deal with quantity.
+    cls = x.__class__
+    y = cls(y, x.unit, copy=False)
+    z = cls(z, x.unit, copy=False)
+    if NUMPY_LT_1_8:  # pragma: no cover
+        # numpy 1.7 has problems concatenating broadcasted arrays.
+        x, y, z = [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
+
+    sh = x.shape
+    sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
+    xyz_value = np.concatenate([c.reshape(sh).value for c in (x, y, z)],
+                               axis=xyz_axis)
+    return cls(xyz_value, unit=x.unit, copy=False)
 
 class RepresentationBase(ShapedLikeNDArray):
     """3D coordinate representations and differentials.
@@ -652,30 +681,7 @@ class CartesianRepresentation(BaseRepresentation):
         xyz : `~astropy.units.Quantity`
             With dimension 3 along ``xyz_axis``.
         """
-        # Add new axis in x, y, z so one can concatenate them around it.
-        # NOTE: just use np.stack once our minimum numpy version is 1.10.
-        result_ndim = self.ndim + 1
-        if not -result_ndim <= xyz_axis < result_ndim:
-            raise IndexError('xyz_axis {0} out of bounds [-{1}, {1})'
-                             .format(xyz_axis, result_ndim))
-        if xyz_axis < 0:
-            xyz_axis += result_ndim
-
-        # Get x, y, z to the same units (this is very fast for identical units)
-        # since np.concatenate cannot deal with quantity.
-        cls = self._x.__class__
-        x = self._x
-        y = cls(self._y, x.unit, copy=False)
-        z = cls(self._z, x.unit, copy=False)
-        if NUMPY_LT_1_8:  # pragma: no cover
-            # numpy 1.7 has problems concatenating broadcasted arrays.
-            x, y, z = [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
-
-        sh = self.shape
-        sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
-        xyz_value = np.concatenate([c.reshape(sh).value for c in (x, y, z)],
-                                   axis=xyz_axis)
-        return cls(xyz_value, unit=x.unit, copy=False)
+        return _combine_xyz(self._x, self._y, self._z, xyz_axis=xyz_axis)
 
     xyz = property(get_xyz)
 
@@ -1795,31 +1801,7 @@ class CartesianDifferential(BaseDifferential):
         xyz : `~astropy.units.Quantity`
             With dimension 3 along ``xyz_axis``.
         """
-        # Add new axis in x, y, z so one can concatenate them around it.
-        # NOTE: just use np.stack once our minimum numpy version is 1.10.
-        result_ndim = self.ndim + 1
-        if not -result_ndim <= xyz_axis < result_ndim:
-            raise IndexError('xyz_axis {0} out of bounds [-{1}, {1})'
-                             .format(xyz_axis, result_ndim))
-        if xyz_axis < 0:
-            xyz_axis += result_ndim
-
-        # Get x, y, z to the same units (this is very fast for identical units)
-        # since np.concatenate cannot deal with quantity.
-        cls = self._d_x.__class__
-        dx = self._d_x
-        dy = cls(self._d_y, dx.unit, copy=False)
-        dz = cls(self._d_z, dx.unit, copy=False)
-        if NUMPY_LT_1_8:  # pragma: no cover
-            # numpy 1.7 has problems concatenating broadcasted arrays.
-            dx, dy, dz = [(c.copy() if 0 in c.strides else c)
-                          for c in (dx, dy, dz)]
-
-        sh = self.shape
-        sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
-        dxyz_value = np.concatenate([c.reshape(sh).value for c in (dx, dy, dz)],
-                                    axis=xyz_axis)
-        return cls(dxyz_value, unit=dx.unit, copy=False)
+        return _combine_xyz(self._d_x, self._d_y, self._d_z, xyz_axis=xyz_axis)
 
     d_xyz = property(get_d_xyz)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -24,10 +24,11 @@ from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
+           "RadialRepresentation",
            "PhysicsSphericalRepresentation", "CylindricalRepresentation",
            "BaseDifferential", "CartesianDifferential", "SphericalDifferential",
            "UnitSphericalDifferential", "PhysicsSphericalDifferential",
-           "CylindricalDifferential"]
+           "CylindricalDifferential", "RadialDifferential"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -937,6 +938,87 @@ class UnitSphericalRepresentation(BaseRepresentation):
             self.to_cartesian().cross(other))
 
 
+class RadialRepresentation(BaseRepresentation):
+    """
+    Representation of the distance of points from the origin.
+
+    Note that this is mostly intended as an internal helper representation.
+    It can do little else but being used as a scale in multiplication.
+
+    Parameters
+    ----------
+    distance : `~astropy.units.Quantity`
+        The distance of the point(s) from the origin.
+
+    copy : bool, optional
+        If True arrays will be copied rather than referenced.
+    """
+
+    attr_classes = OrderedDict([('distance', u.Quantity)])
+
+    def __init__(self, distance, copy=True):
+
+        if not isinstance(distance, u.Quantity):
+            raise TypeError('distance should be a Quantity')
+
+        distance = self.attr_classes['distance'](distance, copy=copy)
+
+        self._distance = distance
+
+    @property
+    def distance(self):
+        """
+        The distance from the origin to the point(s).
+        """
+        return self._distance
+
+    def unit_vectors(self):
+        """Cartesian unit vectors are undefined for radial representation."""
+        raise NotImplementedError('Cartesian unit vectors are undefined for '
+                                  '{0} instances'.format(self.__class__))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        return OrderedDict((('distance', l),))
+
+    def to_cartesian(self):
+        """Cannot convert radial representation to cartesian."""
+        raise NotImplementedError('cannot convert {0} instance to cartesian.'
+                                  .format(self.__class__))
+
+    @classmethod
+    def from_cartesian(cls, cart):
+        """
+        Converts 3D rectangular cartesian coordinates to radial coordinate.
+        """
+        return cls(distance=cart.norm(), copy=False)
+
+    def _scale_operation(self, op, *args):
+        return op(self.distance, *args)
+
+    def norm(self):
+        """Vector norm.
+
+        Just the distance itself.
+
+        Returns
+        -------
+        norm : `~astropy.units.Quantity`
+            Dimensionless ones, with the same shape as the representation.
+        """
+        return self.distance
+
+    def _combine_operation(self, op, other, reverse=False):
+        return NotImplemented
+
+
 class SphericalRepresentation(BaseRepresentation):
     """
     Representation of points in 3D spherical coordinates.
@@ -1508,7 +1590,7 @@ class BaseDifferential(RepresentationBase):
         base_e = base.unit_vectors()
         base_sf = base.scale_factors()
         return cls(*(other.dot(e / base_sf[component])
-                     for component, e in six.iteritems(base_e)))
+                     for component, e in six.iteritems(base_e)), copy=False)
 
     def represent_as(self, other_class, base):
         if other_class is self.__class__:
@@ -1549,6 +1631,11 @@ class BaseDifferential(RepresentationBase):
                 return NotImplemented
 
             return other._combine_operation(op, self_cartesian, not reverse)
+
+    def __sub__(self, other):
+        if isinstance(other, BaseRepresentation):
+            return NotImplemented
+        return super(BaseDifferential, self).__sub__(other)
 
     def norm(self, base=None):
         """Vector norm.
@@ -1599,7 +1686,24 @@ class CartesianDifferential(BaseDifferential):
         return cls(*[getattr(other, c) for c in other.components])
 
 
-class SphericalDifferential(BaseDifferential):
+class BaseSphericalDifferential(BaseDifferential):
+    def _combine_operation(self, op, other, reverse=False):
+        # We allow combining, e.g., Spherical, UnitSpherical and Radial.
+        # Any combination of those yields Spherical; addings things to
+        # other differentials of the same class is left to the superclass.
+        if (isinstance(other, BaseSphericalDifferential) and
+                not isinstance(self, type(other))):
+            all_components = set(self.components) | set(other.components)
+            first, second = (self, other) if not reverse else (other, self)
+            result_args = {c : op(getattr(first, c, 0.), getattr(second, c, 0.))
+                           for c in all_components}
+            return SphericalDifferential(**result_args)
+
+        return super(BaseSphericalDifferential,
+                     self)._combine_operation(op, other, reverse)
+
+
+class SphericalDifferential(BaseSphericalDifferential):
     base_representation = SphericalRepresentation
 
     def represent_as(self, other_class, base=None):
@@ -1607,6 +1711,8 @@ class SphericalDifferential(BaseDifferential):
             return other_class(self.d_lon, self.d_lat)
         elif issubclass(other_class, PhysicsSphericalDifferential):
             return other_class(self.d_lon, -self.d_lat, self.d_distance)
+        elif issubclass(other_class, RadialDifferential):
+            return other_class(self.d_distance)
         else:
             return super(SphericalDifferential,
                          self).represent_as(other_class, base)
@@ -1621,7 +1727,7 @@ class SphericalDifferential(BaseDifferential):
                          cls).from_representation(representation, base)
 
 
-class UnitSphericalDifferential(BaseDifferential):
+class UnitSphericalDifferential(BaseSphericalDifferential):
     base_representation = UnitSphericalRepresentation
 
     def to_cartesian(self, base):
@@ -1645,6 +1751,41 @@ class UnitSphericalDifferential(BaseDifferential):
             return super(UnitSphericalDifferential,
                          cls).from_representation(representation, base)
 
+
+class RadialDifferential(BaseSphericalDifferential):
+    base_representation = RadialRepresentation
+
+    def to_cartesian(self, base):
+        return self.d_distance * base.represent_as(
+            UnitSphericalRepresentation).to_cartesian()
+
+    @classmethod
+    def from_cartesian(cls, other, base):
+        return cls(other.dot(base.represent_as(UnitSphericalRepresentation)),
+                   copy=False)
+
+    @classmethod
+    def from_representation(cls, representation, base=None):
+        if isinstance(representation, SphericalDifferential):
+            return cls(representation.d_lon, representation.d_lat)
+        elif isinstance(representation, PhysicsSphericalDifferential):
+            return cls(representation.d_phi, -representation.d_theta)
+        else:
+            return super(UnitSphericalDifferential,
+                         cls).from_representation(representation, base)
+
+    def _combine_operation(self, op, other, reverse=False):
+        if isinstance(other, self.base_representation):
+            if reverse:
+                first, second = other.distance, self.d_distance
+            else:
+                first, second = self.d_distance, other.distance
+            return other.__class__(op(first, second), copy=False)
+        else:
+            return super(RadialDifferential,
+                         self)._combine_operation(op, other, reverse)
+
+
 class PhysicsSphericalDifferential(BaseDifferential):
     base_representation = PhysicsSphericalRepresentation
 
@@ -1653,6 +1794,8 @@ class PhysicsSphericalDifferential(BaseDifferential):
             return other_class(self.d_phi, -self.d_theta, self.d_r)
         elif issubclass(other_class, UnitSphericalDifferential):
             return other_class(self.d_phi, -self.d_theta)
+        elif issubclass(other_class, RadialDifferential):
+            return other_class(self.d_r)
         else:
             return super(PhysicsSphericalDifferential,
                          self).represent_as(other_class, base)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -25,9 +25,9 @@ from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
            "PhysicsSphericalRepresentation", "CylindricalRepresentation",
-           "BaseOffset", "CartesianOffset", "SphericalOffset",
-           "UnitSphericalOffset", "PhysicsSphericalOffset",
-           "CylindricalOffset"]
+           "BaseDifferential", "CartesianDifferential", "SphericalDifferential",
+           "UnitSphericalDifferential", "PhysicsSphericalDifferential",
+           "CylindricalDifferential"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -64,7 +64,7 @@ def _array2string(values, prefix=''):
 
 
 class RepresentationBase(ShapedLikeNDArray):
-    """Base for 3D coordinate representations and their offsets."""
+    """Base for 3D coordinate representations and their differentials."""
 
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
     # object arrays.
@@ -1401,13 +1401,13 @@ class CylindricalRepresentation(BaseRepresentation):
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
 
-class BaseOffset(RepresentationBase):
-    """Offsets from points on a base representation.
+class BaseDifferential(RepresentationBase):
+    """Differentials from points on a base representation.
 
     Parameters
     ----------
     d_* : `~astropy.units.Quantity`
-        The offsets in terms of the components of the base representation.
+        The differentials in terms of the components of the base representation.
         They can either be given in order in ``args`` or by name in ``kwargs``,
         where the names are the base representation names prefixed by 'd_'.
         The units should be consistent with those of the components, but not
@@ -1479,13 +1479,13 @@ class BaseOffset(RepresentationBase):
                                                    type(base)))
 
     def to_cartesian(self, base):
-        """Convert the offset to 3D rectangular cartesian coordinates.
+        """Convert the differential to 3D rectangular cartesian coordinates.
 
         Parameters
         ----------
         base : instance of ``self.base_representation``
-             The points for which the offsets are to converted: each of the
-             components is multiplied by its unit vectors and scale factors.
+             The points for which the differentials are to converted: each of
+             the components is multiplied by its unit vectors and scale factors.
         """
         self._check_base(base)
         base_e = base.unit_vectors()
@@ -1497,12 +1497,12 @@ class BaseOffset(RepresentationBase):
 
     @classmethod
     def from_cartesian(cls, other, base):
-        """Interpret 3D rectangular cartesian coordinates as offsets.
+        """Interpret 3D rectangular cartesian coordinates as differentials.
 
         Parameters
         ----------
         base : instance of ``self.base_representation``
-            Base relative to which the offsets are defined.
+            Base relative to which the differentials are defined.
         """
         cls._check_base(base)
         base_e = base.unit_vectors()
@@ -1516,7 +1516,7 @@ class BaseOffset(RepresentationBase):
 
         # The default is to convert via cartesian coordinates.
         self_cartesian = self.to_cartesian(base)
-        if issubclass(other_class, BaseOffset):
+        if issubclass(other_class, BaseDifferential):
             base = base.represent_as(other_class.base_representation)
             return other_class.from_cartesian(self_cartesian, base)
         else:
@@ -1525,7 +1525,7 @@ class BaseOffset(RepresentationBase):
     @classmethod
     def from_representation(cls, representation, base):
         cls._check_base(base)
-        if isinstance(representation, BaseOffset):
+        if isinstance(representation, BaseDifferential):
             cartesian = representation.to_cartesian(
                 base.represent_as(representation.base_representation))
         else:
@@ -1559,8 +1559,9 @@ class BaseOffset(RepresentationBase):
         Parameters
         ----------
         base : instance of ``self.base_representation``
-            Base relative to which the offsets are defined, which is required
-            to calculate the physical size of the offset.
+            Base relative to which the differentials are defined. This is
+            required to calculate the physical size of the differential for
+            all but cartesian differentials.
 
         Returns
         -------
@@ -1579,15 +1580,16 @@ class BaseOffset(RepresentationBase):
     def __setattr__(self, attr, value):
         if attr in self.attr_classes:
             raise AttributeError("can't set attribute.")
-        return super(BaseOffset, self).__setattr__(attr, value)
+        return super(BaseDifferential, self).__setattr__(attr, value)
 
     def __delattr__(self, attr):
         if attr in self.attr_classes:
             raise AttributeError("can't delete attribute.")
-        return super(BaseOffset, self).__delattr__(attr)
+        return super(BaseDifferential, self).__delattr__(attr)
 
 
-class CartesianOffset(BaseOffset):
+class CartesianDifferential(BaseDifferential):
+    base_representation = CartesianRepresentation
     def to_cartesian(self, base=None):
         return CartesianRepresentation(*[getattr(self, c) for c
                                          in self.components])
@@ -1597,28 +1599,29 @@ class CartesianOffset(BaseOffset):
         return cls(*[getattr(other, c) for c in other.components])
 
 
-class SphericalOffset(BaseOffset):
+class SphericalDifferential(BaseDifferential):
     base_representation = SphericalRepresentation
 
     def represent_as(self, other_class, base=None):
-        if issubclass(other_class, UnitSphericalOffset):
+        if issubclass(other_class, UnitSphericalDifferential):
             return other_class(self.d_lon, self.d_lat)
-        elif issubclass(other_class, PhysicsSphericalOffset):
+        elif issubclass(other_class, PhysicsSphericalDifferential):
             return other_class(self.d_lon, -self.d_lat, self.d_distance)
         else:
-            return super(SphericalOffset, self).represent_as(other_class, base)
+            return super(SphericalDifferential,
+                         self).represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
-        if isinstance(representation, PhysicsSphericalOffset):
+        if isinstance(representation, PhysicsSphericalDifferential):
             return cls(representation.d_phi, -representation.d_theta,
                        representation.d_r)
         else:
-            return super(SphericalOffset,
+            return super(SphericalDifferential,
                          cls).from_representation(representation, base)
 
 
-class UnitSphericalOffset(BaseOffset):
+class UnitSphericalDifferential(BaseDifferential):
     base_representation = UnitSphericalRepresentation
 
     def to_cartesian(self, base):
@@ -1627,42 +1630,42 @@ class UnitSphericalOffset(BaseOffset):
         elif isinstance(base, PhysicsSphericalRepresentation):
             scale = base.r
         else:
-            return super(UnitSphericalOffset, self).to_cartesian(base)
+            return super(UnitSphericalDifferential, self).to_cartesian(base)
 
         base = base.represent_as(UnitSphericalRepresentation)
-        return scale * super(UnitSphericalOffset, self).to_cartesian(base)
+        return scale * super(UnitSphericalDifferential, self).to_cartesian(base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
-        if isinstance(representation, SphericalOffset):
+        if isinstance(representation, SphericalDifferential):
             return cls(representation.d_lon, representation.d_lat)
-        elif isinstance(representation, PhysicsSphericalOffset):
+        elif isinstance(representation, PhysicsSphericalDifferential):
             return cls(representation.d_phi, -representation.d_theta)
         else:
-            return super(UnitSphericalOffset,
+            return super(UnitSphericalDifferential,
                          cls).from_representation(representation, base)
 
-class PhysicsSphericalOffset(BaseOffset):
+class PhysicsSphericalDifferential(BaseDifferential):
     base_representation = PhysicsSphericalRepresentation
 
     def represent_as(self, other_class, base=None):
-        if issubclass(other_class, SphericalOffset):
+        if issubclass(other_class, SphericalDifferential):
             return other_class(self.d_phi, -self.d_theta, self.d_r)
-        elif issubclass(other_class, UnitSphericalOffset):
+        elif issubclass(other_class, UnitSphericalDifferential):
             return other_class(self.d_phi, -self.d_theta)
         else:
-            return super(PhysicsSphericalOffset,
+            return super(PhysicsSphericalDifferential,
                          self).represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
-        if isinstance(representation, SphericalOffset):
+        if isinstance(representation, SphericalDifferential):
             return cls(representation.d_lon, -representation.d_lat,
                        representation.d_distance)
         else:
-            return super(PhysicsSphericalOffset,
+            return super(PhysicsSphericalDifferential,
                          cls).from_representation(representation, base)
 
 
-class CylindricalOffset(BaseOffset):
+class CylindricalDifferential(BaseDifferential):
     base_representation = CylindricalRepresentation

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -31,10 +31,11 @@ __all__ = ["RepresentationBase", "BaseRepresentation",
            "UnitSphericalDifferential", "RadialDifferential",
            "PhysicsSphericalDifferential", "CylindricalDifferential"]
 
-# Module-level dict mapping representation string alias names to class.
-# This is populated by the metaclass init so all representation classes
-# get registered automatically.
+# Module-level dict mapping representation string alias names to classes.
+# This is populated by the metaclass init so all representation and differential
+# classes get registered automatically.
 REPRESENTATION_CLASSES = {}
+DIFFERENTIAL_CLASSES = {}
 
 def _array2string(values, prefix=''):
     # Mimic numpy >=1.12 array2string, in which structured arrays are
@@ -1543,6 +1544,13 @@ class MetaBaseDifferential(abc.ABCMeta):
             base_attr_classes = cls.base_representation.attr_classes
             cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
                                             for c in base_attr_classes])
+
+        repr_name = cls.get_name()
+        if repr_name in DIFFERENTIAL_CLASSES:
+            raise ValueError("Differential class {0} already defined"
+                             .format(repr_name))
+
+        DIFFERENTIAL_CLASSES[repr_name] = cls
 
         # If not defined explicitly, create properties for the components.
         for component in cls.attr_classes:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -121,6 +121,24 @@ class RepresentationBase(ShapedLikeNDArray):
         for component, attr in zip(components, attrs):
             setattr(self, '_' + component, attr)
 
+    @classmethod
+    def get_name(cls):
+        """Name of the representation or differential.
+
+        In lower case, with any trailing 'representation' or 'differential'
+        removed. (E.g., 'spherical' for
+        `~astropy.coordinates.SphericalRepresentation` or
+        `~astropy.coordinates.SphericalDifferential`.)
+        """
+        name = cls.__name__.lower()
+
+        if name.endswith('representation'):
+            name = name[:-14]
+        elif name.endswith('differential'):
+            name = name[:-12]
+
+        return name
+
     # The two methods that any subclass has to define.
     # Should be replaced by abstractclassmethod once we support only PY3
     @abc.abstractmethod
@@ -404,18 +422,6 @@ class BaseRepresentation(RepresentationBase):
         """
         return representation.represent_as(cls)
 
-    @classmethod
-    def get_name(cls):
-        """Name of the representation.
-
-        In lower case, with any trailing 'representation' removed.
-        (E.g., 'spherical' for `~astropy.coordinates.SphericalRepresentation`.)
-        """
-        name = cls.__name__.lower()
-        if name.endswith('representation'):
-            name = name[:-14]
-        return name
-
     def _scale_operation(self, op, *args):
         """Scale all non-angular components, leaving angular ones unchanged.
 
@@ -663,7 +669,7 @@ class CartesianRepresentation(BaseRepresentation):
         z = cls(self._z, x.unit, copy=False)
         if NUMPY_LT_1_8:  # pragma: no cover
             # numpy 1.7 has problems concatenating broadcasted arrays.
-            x, y, z =  [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
+            x, y, z = [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
 
         sh = self.shape
         sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
@@ -804,6 +810,7 @@ class CartesianRepresentation(BaseRepresentation):
                                 (getattr(self, component) *
                                  getattr(other_c, component)
                                  for component in self.components))
+
     def cross(self, other):
         """Cross product of two representations.
 
@@ -1796,6 +1803,7 @@ class CartesianDifferential(BaseDifferential):
                              .format(xyz_axis, result_ndim))
         if xyz_axis < 0:
             xyz_axis += result_ndim
+
         # Get x, y, z to the same units (this is very fast for identical units)
         # since np.concatenate cannot deal with quantity.
         cls = self._d_x.__class__
@@ -1806,6 +1814,7 @@ class CartesianDifferential(BaseDifferential):
             # numpy 1.7 has problems concatenating broadcasted arrays.
             dx, dy, dz = [(c.copy() if 0 in c.strides else c)
                           for c in (dx, dy, dz)]
+
         sh = self.shape
         sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
         dxyz_value = np.concatenate([c.reshape(sh).value for c in (dx, dy, dz)],

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -39,9 +39,7 @@ REPRESENTATION_CLASSES = {}
 def _array2string(values, prefix=''):
     # Mimic numpy >=1.12 array2string, in which structured arrays are
     # typeset taking into account all printoptions.
-    # TODO: in final numpy 1.12, the scalar case should work as well;
-    # see https://github.com/numpy/numpy/issues/8172
-    if NUMPY_LT_1_12:
+    if NUMPY_LT_1_12:  # pragma: no cover
         # Mimic StructureFormat from numpy >=1.12 assuming float-only data.
         from numpy.core.arrayprint import FloatFormat
         opts = np.get_printoptions()
@@ -85,8 +83,14 @@ class RepresentationBase(ShapedLikeNDArray):
         # make argument a list, so we can pop them off.
         args = list(args)
         components = self.components
-        attrs = [args.pop(0) if args else kwargs.pop(component)
-                 for component in components]
+        attrs = []
+        for component in components:
+            try:
+                attrs.append(args.pop(0) if args else kwargs.pop(component))
+            except KeyError:
+                raise TypeError('__init__() missing 1 required positional '
+                                'argument: {0!r}'.format(component))
+
         copy = args.pop(0) if args else kwargs.pop('copy', True)
 
         if args:
@@ -216,7 +220,7 @@ class RepresentationBase(ShapedLikeNDArray):
     def __truediv__(self, other):
         return self._scale_operation(operator.truediv, other)
 
-    def __div__(self, other):
+    def __div__(self, other):  # pragma: py2
         return self._scale_operation(operator.truediv, other)
 
     def __neg__(self):
@@ -252,7 +256,7 @@ class RepresentationBase(ShapedLikeNDArray):
         The record array fields will have the component names.
         """
         coordinates = [getattr(self, c) for c in self.components]
-        if NUMPY_LT_1_8:
+        if NUMPY_LT_1_8:  # pragma: no cover
             # numpy 1.7 has problems concatenating broadcasted arrays.
             coordinates = [(coo.copy() if 0 in coo.strides else coo)
                            for coo in coordinates]
@@ -657,7 +661,7 @@ class CartesianRepresentation(BaseRepresentation):
         x = self._x
         y = cls(self._y, x.unit, copy=False)
         z = cls(self._z, x.unit, copy=False)
-        if NUMPY_LT_1_8:
+        if NUMPY_LT_1_8:  # pragma: no cover
             # numpy 1.7 has problems concatenating broadcasted arrays.
             x, y, z =  [(c.copy() if 0 in c.strides else c) for c in (x, y, z)]
 
@@ -1914,11 +1918,11 @@ class RadialDifferential(BaseSphericalDifferential):
     @classmethod
     def from_representation(cls, representation, base=None):
         if isinstance(representation, SphericalDifferential):
-            return cls(representation.d_lon, representation.d_lat)
+            return cls(representation.d_distance)
         elif isinstance(representation, PhysicsSphericalDifferential):
-            return cls(representation.d_phi, -representation.d_theta)
+            return cls(representation.d_r)
         else:
-            return super(UnitSphericalDifferential,
+            return super(RadialDifferential,
                          cls).from_representation(representation, base)
 
     def _combine_operation(self, op, other, reverse=False):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -20,7 +20,7 @@ from .distances import Distance
 from ..extern import six
 from ..utils import ShapedLikeNDArray, classproperty
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
-from ..utils.compat.numpy import broadcast_arrays
+from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
@@ -498,6 +498,32 @@ class CartesianRepresentation(BaseRepresentation):
         """
         return self._z
 
+    def unit_vectors(self):
+        """Cartesian unit vectors in the direction of each component.
+
+        Returns
+        -------
+        unit_vectors : dict of `CartesianRepresentation`
+            The keys are the component names.
+        """
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        o = broadcast_to(0.*u.one, self.shape, subok=True)
+        return OrderedDict(
+            (('x', CartesianRepresentation(l, o, o, copy=False)),
+             ('y', CartesianRepresentation(o, l, o, copy=False)),
+             ('z', CartesianRepresentation(o, o, l, copy=False))))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        return OrderedDict((('x', l), ('y', l), ('z', l)))
+
     def get_xyz(self, xyz_axis=0):
         """Return a vector array of the x, y, and z coordinates.
 
@@ -752,15 +778,41 @@ class UnitSphericalRepresentation(BaseRepresentation):
         """
         return self._lat
 
+    def unit_vectors(self):
+        """Cartesian unit vectors in the direction of each component.
+
+        Returns
+        -------
+        unit_vectors : dict of `CartesianRepresentation`
+            The keys are the component names.
+        """
+        sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
+        sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
+        return OrderedDict(
+            (('lon', CartesianRepresentation(-sinlon, coslon, 0., copy=False)),
+             ('lat', CartesianRepresentation(-sinlat*coslon, -sinlat*sinlon,
+                                             coslat, copy=False))))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        coslat = np.cos(self.lat)
+        l = broadcast_to(1./u.radian, self.shape, subok=True)
+        return OrderedDict((('lon', coslat / u.radian), ('lat', l)))
+
     def to_cartesian(self):
         """
         Converts spherical polar coordinates to 3D rectangular cartesian
         coordinates.
         """
-
-        x = u.one * np.cos(self.lat) * np.cos(self.lon)
-        y = u.one * np.cos(self.lat) * np.sin(self.lon)
-        z = u.one * np.sin(self.lat)
+        x = np.cos(self.lat) * np.cos(self.lon)
+        y = np.cos(self.lat) * np.sin(self.lon)
+        z = np.sin(self.lat)
 
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
@@ -947,6 +999,38 @@ class SphericalRepresentation(BaseRepresentation):
         """
         return self._distance
 
+    def unit_vectors(self):
+        """Cartesian unit vectors in the direction of each component.
+
+        Returns
+        -------
+        unit_vectors : dict of `CartesianRepresentation`
+            The keys are the component names.
+        """
+        sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
+        sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
+        return OrderedDict(
+            (('lon', CartesianRepresentation(-sinlon, coslon, 0., copy=False)),
+             ('lat', CartesianRepresentation(-sinlat*coslon, -sinlat*sinlon,
+                                             coslat, copy=False)),
+             ('distance', CartesianRepresentation(coslat*coslon, coslat*sinlon,
+                                                  sinlat, copy=False))))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        d = self.distance / u.radian
+        coslat = np.cos(self.lat)
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        return OrderedDict((('lon', d * coslat),
+                            ('lat', d),
+                            ('distance', l)))
+
     def represent_as(self, other_class):
         # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, PhysicsSphericalRepresentation):
@@ -1091,6 +1175,39 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         """
         return self._distance
 
+    def unit_vectors(self):
+        """Cartesian unit vectors in the direction of each component.
+
+        Returns
+        -------
+        unit_vectors : dict of `CartesianRepresentation`
+            The keys are the component names.
+        """
+        sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
+        sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
+        return OrderedDict(
+            (('phi', CartesianRepresentation(-sinphi, cosphi, 0., copy=False)),
+             ('theta', CartesianRepresentation(costheta*cosphi,
+                                               costheta*sinphi,
+                                               -sintheta, copy=False)),
+             ('r', CartesianRepresentation(sintheta*cosphi, sintheta*sinphi,
+                                           costheta, copy=False))))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        r = self.r / u.radian
+        sintheta = np.sin(self.theta)
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        return OrderedDict((('phi', r * sintheta),
+                            ('theta', r),
+                            ('r', l)))
+
     def represent_as(self, other_class):
         # Take a short cut if the other class is a spherical representation
         if issubclass(other_class, SphericalRepresentation):
@@ -1216,6 +1333,35 @@ class CylindricalRepresentation(BaseRepresentation):
         The height of the point(s).
         """
         return self._z
+
+    def unit_vectors(self):
+        """Cartesian unit vectors in the direction of each component.
+
+        Returns
+        -------
+        unit_vectors : dict of `CartesianRepresentation`
+            The keys are the component names.
+        """
+        sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
+        l = broadcast_to(1., self.shape)
+        return OrderedDict(
+            (('rho', CartesianRepresentation(cosphi, sinphi, 0, copy=False)),
+             ('phi', CartesianRepresentation(-sinphi, cosphi, 0, copy=False)),
+             ('z', CartesianRepresentation(0, 0, l, unit=u.one, copy=False))))
+
+    def scale_factors(self):
+        """Scale factors for each component's direction.
+
+        Returns
+        -------
+        scale_factors : dict of `~astropy.units.Quantity`
+            The keys are the component names.
+        """
+        rho = self.rho / u.radian
+        l = broadcast_to(1.*u.one, self.shape, subok=True)
+        return OrderedDict((('rho', l),
+                            ('phi', rho),
+                            ('z', l)))
 
     @classmethod
     def from_cartesian(cls, cart):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1776,6 +1776,44 @@ class CartesianDifferential(BaseDifferential):
     def from_cartesian(cls, other, base=None):
         return cls(*[getattr(other, c) for c in other.components])
 
+    def get_d_xyz(self, xyz_axis=0):
+        """Return a vector array of the x, y, and z coordinates.
+        Parameters
+        ----------
+        xyz_axis : int, optional
+            The axis in the final array along which the x, y, z components
+            should be stored (default: 0).
+        Returns
+        -------
+        xyz : `~astropy.units.Quantity`
+            With dimension 3 along ``xyz_axis``.
+        """
+        # Add new axis in x, y, z so one can concatenate them around it.
+        # NOTE: just use np.stack once our minimum numpy version is 1.10.
+        result_ndim = self.ndim + 1
+        if not -result_ndim <= xyz_axis < result_ndim:
+            raise IndexError('xyz_axis {0} out of bounds [-{1}, {1})'
+                             .format(xyz_axis, result_ndim))
+        if xyz_axis < 0:
+            xyz_axis += result_ndim
+        # Get x, y, z to the same units (this is very fast for identical units)
+        # since np.concatenate cannot deal with quantity.
+        cls = self._d_x.__class__
+        dx = self._d_x
+        dy = cls(self._d_y, dx.unit, copy=False)
+        dz = cls(self._d_z, dx.unit, copy=False)
+        if NUMPY_LT_1_8:  # pragma: no cover
+            # numpy 1.7 has problems concatenating broadcasted arrays.
+            dx, dy, dz = [(c.copy() if 0 in c.strides else c)
+                          for c in (dx, dy, dz)]
+        sh = self.shape
+        sh = sh[:xyz_axis] + (1,) + sh[xyz_axis:]
+        dxyz_value = np.concatenate([c.reshape(sh).value for c in (dx, dy, dz)],
+                                    axis=xyz_axis)
+        return cls(dxyz_value, unit=dx.unit, copy=False)
+
+    d_xyz = property(get_d_xyz)
+
 
 class BaseSphericalDifferential(BaseDifferential):
     def _combine_operation(self, op, other, reverse=False):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -22,10 +22,10 @@ from ..utils import ShapedLikeNDArray, classproperty, sharedmethod
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
+# Note: Offset classes gets added to this at the end.
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
-           "PhysicsSphericalRepresentation", "CylindricalRepresentation",
-           "SphericalOffset"]
+           "PhysicsSphericalRepresentation", "CylindricalRepresentation"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -60,67 +60,13 @@ def _array2string(values, prefix=''):
     return np.array2string(values, formatter=formatter, style=fmt,
                            separator=', ', prefix=prefix)
 
-# Need to subclass ABCMeta rather than type, so that this meta class can be
-# combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
-# "TypeError: metaclass conflict: the metaclass of a derived class must be a
-#  (non-strict) subclass of the metaclasses of all its bases"
-class MetaBaseRepresentation(abc.ABCMeta):
-    def __init__(cls, name, bases, dct):
-        super(MetaBaseRepresentation, cls).__init__(name, bases, dct)
 
-        # Register representation name (except for BaseRepresentation)
-        if (cls.__name__ == 'BaseRepresentation' or
-                cls.__name__.endswith('Offset')):
-            return
-
-        if name != 'BaseRepresentation' and 'attr_classes' not in dct:
-            raise NotImplementedError('Representations must have an '
-                                      '"attr_classes" class attribute.')
-
-        repr_name = cls.get_name()
-
-        if repr_name in REPRESENTATION_CLASSES:
-            raise ValueError("Representation class {0} already defined".format(repr_name))
-
-        REPRESENTATION_CLASSES[repr_name] = cls
-
-
-@six.add_metaclass(MetaBaseRepresentation)
-class BaseRepresentation(ShapedLikeNDArray):
-    """
-    Base Representation object, for representing a point in a 3D coordinate
-    system.
-
-    Notes
-    -----
-    All representation classes should subclass this base representation
-    class. All subclasses should then define a ``to_cartesian`` method and a
-    ``from_cartesian`` class method. By default, transformations are done via
-    the cartesian system, but classes that want to define a smarter
-    transformation path can overload the ``represent_as`` method.
-    Furthermore, all classes must define an ``attr_classes`` attribute, an
-    `~collections.OrderedDict` which maps component names to the class that
-    creates them.  They can also define a `recommended_units` dictionary, which
-    maps component names to the units they are best presented to users in.  Note
-    that frame classes may override this with their own preferred units.
-    """
-
-    recommended_units = {}  # subclasses can override
+class RepresentationBase(ShapedLikeNDArray):
+    """Base for 3D coordinate representations and their offsets."""
 
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
     # object arrays.
     __array_priority__ = 50000
-
-    def represent_as(self, other_class):
-        if other_class == self.__class__:
-            return self
-        else:
-            # The default is to convert via cartesian coordinates
-            return other_class.from_cartesian(self.to_cartesian())
-
-    @classmethod
-    def from_representation(cls, representation):
-        return representation.represent_as(cls)
 
     # Should be replaced by abstractclassmethod once we support only Python 3
     @abc.abstractmethod
@@ -135,13 +81,6 @@ class BaseRepresentation(ShapedLikeNDArray):
     def components(self):
         """A tuple with the in-order names of the coordinate components"""
         return tuple(self.attr_classes)
-
-    @classmethod
-    def get_name(cls):
-        name = cls.__name__.lower()
-        if name.endswith('representation'):
-            name = name[:-14]
-        return name
 
     def _apply(self, method, *args, **kwargs):
         """Create a new representation with ``method`` applied to the arrays.
@@ -212,6 +151,45 @@ class BaseRepresentation(ShapedLikeNDArray):
                 else:
                     reshaped.append(val)
 
+    @abc.abstractmethod
+    def _scale_operation(self, op, *args):
+        raise NotImplementedError
+
+    def __mul__(self, other):
+        return self._scale_operation(operator.mul, other)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __truediv__(self, other):
+        return self._scale_operation(operator.truediv, other)
+
+    def __div__(self, other):
+        return self._scale_operation(operator.truediv, other)
+
+    def __neg__(self):
+        return self._scale_operation(operator.neg)
+
+    # Follow numpy convention and make an independent copy.
+    def __pos__(self):
+        return self.copy()
+
+    @abc.abstractmethod
+    def _combine_operation(self, op, other, reverse=False):
+        raise NotImplementedError
+
+    def __add__(self, other):
+        return self._combine_operation(operator.add, other)
+
+    def __radd__(self, other):
+        return self._combine_operation(operator.add, other, reverse=True)
+
+    def __sub__(self, other):
+        return self._combine_operation(operator.sub, other)
+
+    def __rsub__(self, other):
+        return self._combine_operation(operator.sub, other, reverse=True)
+
     @property
     def _values(self):
         """Turn the coordinates into a record array with the coordinate values.
@@ -247,6 +225,82 @@ class BaseRepresentation(ShapedLikeNDArray):
                            for component in self.components]))
         return unitstr
 
+    def __str__(self):
+        return '{0} {1:s}'.format(_array2string(self._values), self._unitstr)
+
+    def __repr__(self):
+        prefixstr = '    '
+        arrstr = _array2string(self._values, prefix=prefixstr)
+
+
+        unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
+        return '<{0} ({1}) {2:s}\n{3}{4}>'.format(
+            self.__class__.__name__, ', '.join(self.components),
+            unitstr, prefixstr, arrstr)
+
+
+# Need to subclass ABCMeta rather than type, so that this meta class can be
+# combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
+# "TypeError: metaclass conflict: the metaclass of a derived class must be a
+#  (non-strict) subclass of the metaclasses of all its bases"
+class MetaBaseRepresentation(abc.ABCMeta):
+    def __init__(cls, name, bases, dct):
+        super(MetaBaseRepresentation, cls).__init__(name, bases, dct)
+
+        # Register representation name (except for BaseRepresentation)
+        if cls.__name__ == 'BaseRepresentation':
+            return
+
+        if name != 'BaseRepresentation' and 'attr_classes' not in dct:
+            raise NotImplementedError('Representations must have an '
+                                      '"attr_classes" class attribute.')
+
+        repr_name = cls.get_name()
+
+        if repr_name in REPRESENTATION_CLASSES:
+            raise ValueError("Representation class {0} already defined".format(repr_name))
+
+        REPRESENTATION_CLASSES[repr_name] = cls
+
+
+@six.add_metaclass(MetaBaseRepresentation)
+class BaseRepresentation(RepresentationBase):
+    """Base for representing a point in a 3D coordinate system.
+
+    Notes
+    -----
+    All representation classes should subclass this base representation
+    class. All subclasses should then define a ``to_cartesian`` method and a
+    ``from_cartesian`` class method. By default, transformations are done via
+    the cartesian system, but classes that want to define a smarter
+    transformation path can overload the ``represent_as`` method.
+    Furthermore, all classes must define an ``attr_classes`` attribute, an
+    `~collections.OrderedDict` which maps component names to the class that
+    creates them.  They can also define a `recommended_units` dictionary, which
+    maps component names to the units they are best presented to users in.  Note
+    that frame classes may override this with their own preferred units.
+    """
+
+    recommended_units = {}  # subclasses can override
+
+    def represent_as(self, other_class):
+        if other_class == self.__class__:
+            return self
+        else:
+            # The default is to convert via cartesian coordinates
+            return other_class.from_cartesian(self.to_cartesian())
+
+    @classmethod
+    def from_representation(cls, representation):
+        return representation.represent_as(cls)
+
+    @classmethod
+    def get_name(cls):
+        name = cls.__name__.lower()
+        if name.endswith('representation'):
+            name = name[:-14]
+        return name
+
     def _scale_operation(self, op, *args):
         results = []
         for component, cls in self.attr_classes.items():
@@ -264,43 +318,12 @@ class BaseRepresentation(ShapedLikeNDArray):
         except Exception:
             return NotImplemented
 
-    def __mul__(self, other):
-        return self._scale_operation(operator.mul, other)
-
-    def __rmul__(self, other):
-        return self.__mul__(other)
-
-    def __truediv__(self, other):
-        return self._scale_operation(operator.truediv, other)
-
-    def __div__(self, other):
-        return self._scale_operation(operator.truediv, other)
-
-    def __neg__(self):
-        return self._scale_operation(operator.neg)
-
-    # Follow numpy convention and make an independent copy.
-    def __pos__(self):
-        return self.copy()
-
     def _combine_operation(self, op, other, reverse=False):
         result = self.to_cartesian()._combine_operation(op, other, reverse)
         if result is NotImplemented:
             return NotImplemented
         else:
             return self.from_cartesian(result)
-
-    def __add__(self, other):
-        return self._combine_operation(operator.add, other)
-
-    def __radd__(self, other):
-        return self._combine_operation(operator.add, other, reverse=True)
-
-    def __sub__(self, other):
-        return self._combine_operation(operator.sub, other)
-
-    def __rsub__(self, other):
-        return self._combine_operation(operator.sub, other, reverse=True)
 
     def norm(self):
         """Vector norm.
@@ -392,19 +415,6 @@ class BaseRepresentation(ShapedLikeNDArray):
             same type of representation as ``self``.
         """
         return self.from_cartesian(self.to_cartesian().cross(other))
-
-    def __str__(self):
-        return '{0} {1:s}'.format(_array2string(self._values), self._unitstr)
-
-    def __repr__(self):
-        prefixstr = '    '
-        arrstr = _array2string(self._values, prefix=prefixstr)
-
-
-        unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
-        return '<{0} ({1}) {2:s}\n{3}{4}>'.format(
-            self.__class__.__name__, ', '.join(self.components),
-            unitstr, prefixstr, arrstr)
 
 
 class CartesianRepresentation(BaseRepresentation):
@@ -1389,7 +1399,7 @@ class CylindricalRepresentation(BaseRepresentation):
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
 
-class BaseOffset(BaseRepresentation):
+class BaseOffset(RepresentationBase):
     """Offsets from points on a base representation.
 
     Parameters
@@ -1548,5 +1558,19 @@ class BaseOffset(BaseRepresentation):
         return super(BaseOffset, self).__delattr__(attr)
 
 
-class SphericalOffset(BaseOffset):
-    base_representation = SphericalRepresentation
+class CartesianOffset(BaseOffset):
+    def to_cartesian(self, base=None):
+        return CartesianRepresentation(*[getattr(self, c) for c
+                                         in self.components])
+
+    @classmethod
+    def from_cartesian(cls, other, base=None):
+        return cls(*[getattr(other, c) for c in other.components])
+
+
+for r, r_cls in REPRESENTATION_CLASSES.items():
+    name = r_cls.__name__.replace('Representation', 'Offset')
+    if name not in locals():
+        locals()[name] = type(name, (BaseOffset,),
+                              {'base_representation': r_cls})
+        __all__.append(name)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -19,7 +19,7 @@ from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..extern import six
 from ..utils import ShapedLikeNDArray, classproperty
-from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
+from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12, override__dir__
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
@@ -70,6 +70,34 @@ class RepresentationBase(ShapedLikeNDArray):
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
     # object arrays.
     __array_priority__ = 50000
+
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+        components = self.components
+        attrs = [args.pop(0) if args else kwargs.pop(component)
+                 for component in components]
+        copy = args.pop(0) if args else kwargs.pop('copy', True)
+
+        if args:
+            raise TypeError('unexpected arguments: {0}'.format(args))
+
+        if kwargs:
+            for component in components:
+                if component in kwargs:
+                    raise TypeError("__init__() got multiple values for "
+                                    "argument {0!r}".format(component))
+
+            raise TypeError('unexpected keyword arguments: {0}'.format(kwargs))
+
+        attrs = [self.attr_classes[component](attr, copy=copy)
+                 for component, attr in zip(components, attrs)]
+        try:
+            attrs = broadcast_arrays(*attrs, subok=True)
+        except ValueError:
+            raise ValueError("Input parameters cannot be broadcast")
+
+        for component, attr in zip(components, attrs):
+            setattr(self, '_' + component, attr)
 
     # Should be replaced by abstractclassmethod once we support only Python 3
     @abc.abstractmethod
@@ -254,7 +282,7 @@ class MetaBaseRepresentation(abc.ABCMeta):
         if cls.__name__ == 'BaseRepresentation':
             return
 
-        if name != 'BaseRepresentation' and 'attr_classes' not in dct:
+        if 'attr_classes' not in dct:
             raise NotImplementedError('Representations must have an '
                                       '"attr_classes" class attribute.')
 
@@ -447,10 +475,6 @@ class CartesianRepresentation(BaseRepresentation):
 
     def __init__(self, x, y=None, z=None, unit=None, xyz_axis=None, copy=True):
 
-        if unit is None and not hasattr(x, 'unit'):
-            raise TypeError('x should have a unit unless an explicit unit '
-                            'is passed in.')
-
         if y is None and z is None:
             if xyz_axis is not None and xyz_axis != 0:
                 x = np.rollaxis(x, xyz_axis, 0)
@@ -463,33 +487,16 @@ class CartesianRepresentation(BaseRepresentation):
             raise ValueError("x, y, and z are required to instantiate {0}"
                              .format(self.__class__.__name__))
 
-        try:
-            x = self.attr_classes['x'](x, unit=unit, copy=copy)
-            y = self.attr_classes['y'](y, unit=unit, copy=copy)
-            z = self.attr_classes['z'](z, unit=unit, copy=copy)
-        except u.UnitsError:
-            raise u.UnitsError('x, y, and z should have a unit consistent with '
-                               '{0}'.format(unit))
-        except:
-            raise TypeError('x, y, and z should be able to initialize ' +
-                            ('a {0}'.format(self.attr_classes['x'].__name__))
-                             if len(set(self.attr_classes.values)) == 1 else
-                            ('{0}, {1}, and {2}, resp.'.format(
-                                cls.__name__ for cls in
-                                self.attr_classes.values())))
+        if unit is not None:
+            x = u.Quantity(x, unit, copy=copy, subok=True)
+            y = u.Quantity(y, unit, copy=copy, subok=True)
+            z = u.Quantity(z, unit, copy=copy, subok=True)
+            copy = False
 
-        if not (x.unit.physical_type ==
-                y.unit.physical_type == z.unit.physical_type):
+        super(CartesianRepresentation, self).__init__(x, y, z, copy=copy)
+        if not (self._x.unit.physical_type ==
+                self._y.unit.physical_type == self._z.unit.physical_type):
             raise u.UnitsError("x, y, and z should have matching physical types")
-
-        try:
-            x, y, z = broadcast_arrays(x, y, z, subok=True)
-        except ValueError:
-            raise ValueError("Input parameters x, y, and z cannot be broadcast")
-
-        self._x = x
-        self._y = y
-        self._z = z
 
     @property
     def x(self):
@@ -760,23 +767,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
         return SphericalRepresentation
 
     def __init__(self, lon, lat, copy=True):
-
-        if not isinstance(lon, u.Quantity) or isinstance(lon, Latitude):
-            raise TypeError('lon should be a Quantity, Angle, or Longitude')
-
-        if not isinstance(lat, u.Quantity) or isinstance(lat, Longitude):
-            raise TypeError('lat should be a Quantity, Angle, or Latitude')
-        # Let the Longitude and Latitude classes deal with e.g. parsing
-        lon = self.attr_classes['lon'](lon, copy=copy)
-        lat = self.attr_classes['lat'](lat, copy=copy)
-
-        try:
-            lon, lat = broadcast_arrays(lon, lat, subok=True)
-        except ValueError:
-            raise ValueError("Input parameters lon and lat cannot be broadcast")
-
-        self._lon = lon
-        self._lat = lat
+        super(UnitSphericalRepresentation,
+              self).__init__(lon, lat, copy=copy)
 
     @property
     def lon(self):
@@ -957,13 +949,7 @@ class RadialRepresentation(BaseRepresentation):
     attr_classes = OrderedDict([('distance', u.Quantity)])
 
     def __init__(self, distance, copy=True):
-
-        if not isinstance(distance, u.Quantity):
-            raise TypeError('distance should be a Quantity')
-
-        distance = self.attr_classes['distance'](distance, copy=copy)
-
-        self._distance = distance
+        super(RadialRepresentation, self).__init__(distance, copy=copy)
 
     @property
     def distance(self):
@@ -1048,30 +1034,10 @@ class SphericalRepresentation(BaseRepresentation):
     _unit_representation = UnitSphericalRepresentation
 
     def __init__(self, lon, lat, distance, copy=True):
-
-        if not isinstance(lon, u.Quantity) or isinstance(lon, Latitude):
-            raise TypeError('lon should be a Quantity, Angle, or Longitude')
-
-        if not isinstance(lat, u.Quantity) or isinstance(lat, Longitude):
-            raise TypeError('lat should be a Quantity, Angle, or Latitude')
-
-        # Let the Longitude and Latitude classes deal with e.g. parsing
-        lon = self.attr_classes['lon'](lon, copy=copy)
-        lat = self.attr_classes['lat'](lat, copy=copy)
-
-        distance = self.attr_classes['distance'](distance, copy=copy)
-        if distance.unit.physical_type == 'length':
-            distance = distance.view(Distance)
-
-        try:
-            lon, lat, distance = broadcast_arrays(lon, lat, distance,
-                                                  subok=True)
-        except ValueError:
-            raise ValueError("Input parameters lon, lat, and distance cannot be broadcast")
-
-        self._lon = lon
-        self._lat = lat
-        self._distance = distance
+        super(SphericalRepresentation,
+              self).__init__(lon, lat, distance, copy=copy)
+        if self._distance.unit.physical_type == 'length':
+            self._distance = self._distance.view(Distance)
 
     @property
     def lon(self):
@@ -1215,39 +1181,23 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
     recommended_units = {'phi': u.deg, 'theta': u.deg}
 
     def __init__(self, phi, theta, r, copy=True):
-
-        if not isinstance(phi, u.Quantity) or isinstance(phi, Latitude):
-            raise TypeError('phi should be a Quantity or Angle')
-
-        if not isinstance(theta, u.Quantity) or isinstance(theta, Longitude):
-            raise TypeError('phi should be a Quantity or Angle')
-
-        # Let the Longitude and Latitude classes deal with e.g. parsing
-        phi = self.attr_classes['phi'](phi, copy=copy)
-        theta = self.attr_classes['theta'](theta, copy=copy)
+        super(PhysicsSphericalRepresentation,
+              self).__init__(phi, theta, r, copy=copy)
 
         # Wrap/validate phi/theta
         if copy:
-            phi = phi.wrap_at(360 * u.deg)
+            self._phi = self._phi.wrap_at(360 * u.deg)
         else:
             # necessary because the above version of `wrap_at` has to be a copy
-            phi.wrap_at(360 * u.deg, inplace=True)
-        if np.any(theta.value < 0.) or np.any(theta.value > 180.):
-            raise ValueError('Inclination angle(s) must be within 0 deg <= angle <= 180 deg, '
+            self._phi.wrap_at(360 * u.deg, inplace=True)
+
+        if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
+            raise ValueError('Inclination angle(s) must be within '
+                             '0 deg <= angle <= 180 deg, '
                              'got {0}'.format(theta.to(u.degree)))
 
-        r = self.attr_classes['r'](r, copy=copy)
-        if r.unit.physical_type == 'length':
-            r = r.view(Distance)
-
-        try:
-            phi, theta, r = broadcast_arrays(phi, theta, r, subok=True)
-        except ValueError:
-            raise ValueError("Input parameters phi, theta, and r cannot be broadcast")
-
-        self._phi = phi
-        self._theta = theta
-        self._distance = r
+        if self._r.unit.physical_type == 'length':
+            self._r = self._r.view(Distance)
 
     @property
     def phi(self):
@@ -1268,7 +1218,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         """
         The distance from the origin to the point(s).
         """
-        return self._distance
+        return self._r
 
     def unit_vectors(self):
         """Cartesian unit vectors in the direction of each component.
@@ -1388,25 +1338,11 @@ class CylindricalRepresentation(BaseRepresentation):
     recommended_units = {'phi': u.deg}
 
     def __init__(self, rho, phi, z, copy=True):
+        super(CylindricalRepresentation,
+              self).__init__(rho, phi, z, copy=copy)
 
-        if not isinstance(phi, u.Quantity) or isinstance(phi, Latitude):
-            raise TypeError('phi should be a Quantity or Angle')
-
-        rho = self.attr_classes['rho'](rho, copy=copy)
-        phi = self.attr_classes['phi'](phi, copy=copy)
-        z = self.attr_classes['z'](z, copy=copy)
-
-        if not (rho.unit.physical_type == z.unit.physical_type):
+        if not self._rho.unit.is_equivalent(self._z.unit):
             raise u.UnitsError("rho and z should have matching physical types")
-
-        try:
-            rho, phi, z = broadcast_arrays(rho, phi, z, subok=True)
-        except ValueError:
-            raise ValueError("Input parameters rho, phi, and z cannot be broadcast")
-
-        self._rho = rho
-        self._phi = phi
-        self._z = z
 
     @property
     def rho(self):
@@ -1483,6 +1419,29 @@ class CylindricalRepresentation(BaseRepresentation):
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
 
+class MetaBaseDifferential(abc.ABCMeta):
+    """Set default ``attr_classes`` and component getters on a Differential.
+
+    For these, the components are those of the base representation prefixed
+    by 'd_', and the class is `~astropy.units.Quantity`.
+    """
+    def __init__(cls, name, bases, dct):
+        super(MetaBaseDifferential, cls).__init__(name, bases, dct)
+
+        if cls.__name__ in ('BaseDifferential', 'BaseSphericalDifferential'):
+            return
+
+        if 'base_representation' not in dct:
+            raise NotImplementedError('Differential representations must have a'
+                                      '"base_representation" class attribute.')
+
+        if not hasattr(cls, 'attr_classes'):
+            base_attr_classes = cls.base_representation.attr_classes
+            cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
+                                            for c in base_attr_classes])
+
+
+@six.add_metaclass(MetaBaseDifferential)
 class BaseDifferential(RepresentationBase):
     """Differentials from points on a base representation.
 
@@ -1492,66 +1451,11 @@ class BaseDifferential(RepresentationBase):
         The differentials in terms of the components of the base representation.
         They can either be given in order in ``args`` or by name in ``kwargs``,
         where the names are the base representation names prefixed by 'd_'.
-        The units should be consistent with those of the components, but not
-        necessarily equivalent (e.g., for a spherical representation, they can
-        be rotation rates (angular per time) for longitude and latitude, and
-        velocity for distance.
+        The units should be equivalent between different angular and different
+        physical components (e.g., between ``d_lon`` and ``d_theta``).
     copy : bool, optional
         If True arrays will be copied rather than referenced.
     """
-
-    base_representation = None
-    attr_classes = OrderedDict()
-
-    def __init__(self, *args, **kwargs):
-        self.attr_classes = OrderedDict()
-        attrs = []
-        names = []
-        regular_units = []
-        angular_units = []
-        base_attr_classes = self.base_representation.attr_classes
-        args = list(args)
-        for component, base_attr_cls in base_attr_classes.items():
-            name = 'd_' + component
-            attr = args.pop(0) if args else kwargs.pop(name)
-            attrs.append(attr)
-            names.append(name)
-            try:
-                unit = attr.unit
-            except AttributeError:
-                raise TypeError('attributes should have units.')
-            if issubclass(base_attr_cls, Angle):
-                angular_units.append(unit)
-            else:
-                regular_units.append(unit)
-
-        copy = args.pop(0) if args else kwargs.pop('copy', True)
-        if args:
-            raise TypeError('unexpected arguments: {0}'.format(args))
-
-        if kwargs:
-            for name in names:
-                if name in kwargs:
-                    raise TypeError("__init__() got multiple values for "
-                                    "argument {0!r}".format(name))
-
-            raise TypeError('unexpected keyword arguments: {0}'.format(kwargs))
-
-        for units in regular_units, angular_units:
-            for unit in units[1:]:
-                if not unit.is_equivalent(units[0]):
-                    raise u.UnitsError('inconsistent units: {0}.'
-                                       .format(units))
-
-        attrs = [u.Quantity(a, copy=copy, subok=True) for a in attrs]
-        try:
-            attrs = broadcast_arrays(*attrs, subok=True)
-        except ValueError:
-            raise ValueError("Input parameters cannot be broadcast")
-
-        for name, attr in zip(names, attrs):
-            self.attr_classes[name] = type(attr)
-            setattr(self, '_' + name, attr)
 
     @classmethod
     def _check_base(cls, base):
@@ -1573,9 +1477,8 @@ class BaseDifferential(RepresentationBase):
         base_e = base.unit_vectors()
         base_sf = base.scale_factors()
         return functools.reduce(
-            operator.add, (getattr(self, 'd_' + component) *
-                           base_sf[component] * e
-                           for component, e in six.iteritems(base_e)))
+            operator.add, (getattr(self, d_c) * base_sf[c] * base_e[c]
+                           for d_c, c in zip(self.components, base.components)))
 
     @classmethod
     def from_cartesian(cls, other, base):
@@ -1658,6 +1561,10 @@ class BaseDifferential(RepresentationBase):
         return self.to_cartesian(base).norm()
 
     # ensure components behave as if they were properties.
+    @override__dir__
+    def __dir__(self):
+        return self.components
+
     def __getattr__(self, attr):
         if attr in self.attr_classes:
             return getattr(self, '_' + attr)
@@ -1677,6 +1584,33 @@ class BaseDifferential(RepresentationBase):
 
 class CartesianDifferential(BaseDifferential):
     base_representation = CartesianRepresentation
+    def __init__(self, d_x, d_y=None, d_z=None, unit=None, xyz_axis=None,
+                 copy=True):
+
+        if d_y is None and d_z is None:
+            if xyz_axis is not None and xyz_axis != 0:
+                d_x = np.rollaxis(d_x, xyz_axis, 0)
+            d_x, d_y, d_z = d_x
+        elif xyz_axis is not None:
+            raise ValueError("xyz_axis should only be set if d_x, d_y, and d_z "
+                             "are in a single array passed in through d_x, "
+                             "i.e., d_y and d_z should not be not given.")
+        elif ((d_y is None and d_z is not None) or
+              (d_y is not None and d_z is None)):
+            raise ValueError("d_x, d_y, and d_z are required to instantiate {0}"
+                             .format(self.__class__.__name__))
+
+        if unit is not None:
+            d_x = u.Quantity(d_x, unit, copy=copy, subok=True)
+            d_y = u.Quantity(d_y, unit, copy=copy, subok=True)
+            d_z = u.Quantity(d_z, unit, copy=copy, subok=True)
+            copy = False
+
+        super(CartesianDifferential, self).__init__(d_x, d_y, d_z, copy=copy)
+        if not (self._d_x.unit.is_equivalent(self._d_y.unit) and
+                self._d_x.unit.is_equivalent(self._d_z.unit)):
+            raise u.UnitsError('d_x, d_y and d_z should have equivalent units.')
+
     def to_cartesian(self, base=None):
         return CartesianRepresentation(*[getattr(self, c) for c
                                          in self.components])
@@ -1706,6 +1640,12 @@ class BaseSphericalDifferential(BaseDifferential):
 class SphericalDifferential(BaseSphericalDifferential):
     base_representation = SphericalRepresentation
 
+    def __init__(self, d_lon, d_lat, d_distance, copy=True):
+        super(SphericalDifferential, self).__init__(d_lon, d_lat, d_distance,
+                                                    copy=copy)
+        if not self._d_lon.unit.is_equivalent(self._d_lat.unit):
+            raise u.UnitsError('d_lon and d_lat should have equivalent units.')
+
     def represent_as(self, other_class, base=None):
         if issubclass(other_class, UnitSphericalDifferential):
             return other_class(self.d_lon, self.d_lat)
@@ -1729,6 +1669,12 @@ class SphericalDifferential(BaseSphericalDifferential):
 
 class UnitSphericalDifferential(BaseSphericalDifferential):
     base_representation = UnitSphericalRepresentation
+
+    def __init__(self, d_lon, d_lat, copy=True):
+        super(UnitSphericalDifferential,
+              self).__init__(d_lon, d_lat, copy=copy)
+        if not self._d_lon.unit.is_equivalent(self._d_lat.unit):
+            raise u.UnitsError('d_lon and d_lat should have equivalent units.')
 
     def to_cartesian(self, base):
         if isinstance(base, SphericalRepresentation):
@@ -1789,6 +1735,13 @@ class RadialDifferential(BaseSphericalDifferential):
 class PhysicsSphericalDifferential(BaseDifferential):
     base_representation = PhysicsSphericalRepresentation
 
+    def __init__(self, d_phi, d_theta, d_r, copy=True):
+        super(PhysicsSphericalDifferential,
+              self).__init__(d_phi, d_theta, d_r, copy=copy)
+        if not self._d_phi.unit.is_equivalent(self._d_theta.unit):
+            raise u.UnitsError('d_phi and d_theta should have equivalent '
+                               'units.')
+
     def represent_as(self, other_class, base=None):
         if issubclass(other_class, SphericalDifferential):
             return other_class(self.d_phi, -self.d_theta, self.d_r)
@@ -1812,3 +1765,9 @@ class PhysicsSphericalDifferential(BaseDifferential):
 
 class CylindricalDifferential(BaseDifferential):
     base_representation = CylindricalRepresentation
+
+    def __init__(self, d_rho, d_phi, d_z, copy=False):
+        super(CylindricalDifferential,
+              self).__init__(d_rho, d_phi, d_z, copy=copy)
+        if not self._d_rho.unit.is_equivalent(self._d_z.unit):
+            raise u.UnitsError("d_rho and d_z should have equivalent units.")

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -18,13 +18,14 @@ import astropy.units as u
 from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..extern import six
-from ..utils import ShapedLikeNDArray, classproperty
+from ..utils import ShapedLikeNDArray, classproperty, sharedmethod
 from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
            "SphericalRepresentation", "UnitSphericalRepresentation",
-           "PhysicsSphericalRepresentation", "CylindricalRepresentation"]
+           "PhysicsSphericalRepresentation", "CylindricalRepresentation",
+           "SphericalOffset"]
 
 # Module-level dict mapping representation string alias names to class.
 # This is populated by the metaclass init so all representation classes
@@ -67,13 +68,14 @@ class MetaBaseRepresentation(abc.ABCMeta):
     def __init__(cls, name, bases, dct):
         super(MetaBaseRepresentation, cls).__init__(name, bases, dct)
 
+        # Register representation name (except for BaseRepresentation)
+        if (cls.__name__ == 'BaseRepresentation' or
+                cls.__name__.endswith('Offset')):
+            return
+
         if name != 'BaseRepresentation' and 'attr_classes' not in dct:
             raise NotImplementedError('Representations must have an '
                                       '"attr_classes" class attribute.')
-
-        # Register representation name (except for BaseRepresentation)
-        if cls.__name__ == 'BaseRepresentation':
-            return
 
         repr_name = cls.get_name()
 
@@ -279,8 +281,7 @@ class BaseRepresentation(ShapedLikeNDArray):
 
     # Follow numpy convention and make an independent copy.
     def __pos__(self):
-        return self.__class__(*(getattr(self, component)
-                                for component in self.components), copy=True)
+        return self.copy()
 
     def _combine_operation(self, op, other, reverse=False):
         result = self.to_cartesian()._combine_operation(op, other, reverse)
@@ -1386,3 +1387,166 @@ class CylindricalRepresentation(BaseRepresentation):
         z = self.z
 
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+
+
+class BaseOffset(BaseRepresentation):
+    """Offsets from points on a base representation.
+
+    Parameters
+    ----------
+    d_* : `~astropy.units.Quantity`
+        The offsets in terms of the components of the base representation.
+        They can either be given in order in ``args`` or by name in ``kwargs``,
+        where the names are the base representation names prefixed by 'd_'.
+        The units should be consistent with those of the components, but not
+        necessarily equivalent (e.g., for a spherical representation, they can
+        be rotation rates (angular per time) for longitude and latitude, and
+        velocity for distance.
+    copy : bool, optional
+        If True arrays will be copied rather than referenced.
+    """
+
+    base_representation = None
+    attr_classes = OrderedDict()
+
+    def __init__(self, *args, **kwargs):
+        self.attr_classes = OrderedDict()
+        attrs = []
+        names = []
+        regular_units = []
+        angular_units = []
+        base_attr_classes = self.base_representation.attr_classes
+        args = list(args)
+        for component, base_attr_cls in base_attr_classes.items():
+            name = 'd_' + component
+            attr = args.pop(0) if args else kwargs.pop(name)
+            attrs.append(attr)
+            names.append(name)
+            try:
+                unit = attr.unit
+            except AttributeError:
+                raise TypeError('attributes should have units.')
+            if issubclass(base_attr_cls, Angle):
+                angular_units.append(unit)
+            else:
+                regular_units.append(unit)
+
+        copy = args.pop(0) if args else kwargs.pop('copy', True)
+        if args:
+            raise TypeError('unexpected arguments: {0}'.format(args))
+
+        if kwargs:
+            for name in names:
+                if name in kwargs:
+                    raise TypeError("__init__() got multiple values for "
+                                    "argument {0!r}".format(name))
+
+            raise TypeError('unexpected keyword arguments: {0}'.format(kwargs))
+
+        for units in regular_units, angular_units:
+            for unit in units[1:]:
+                if not unit.is_equivalent(units[0]):
+                    raise u.UnitsError('inconsistent units: {0}.'
+                                       .format(units))
+
+        attrs = [u.Quantity(a, copy=copy, subok=True) for a in attrs]
+        try:
+            attrs = broadcast_arrays(*attrs, subok=True)
+        except ValueError:
+            raise ValueError("Input parameters cannot be broadcast")
+
+        for name, attr in zip(names, attrs):
+            self.attr_classes[name] = type(attr)
+            setattr(self, '_' + name, attr)
+
+    @sharedmethod
+    def _check_base(self, base):
+        if not isinstance(base, self.base_representation):
+            raise TypeError('need a base of the correct representation type, '
+                            '{0}, not {1}.'.format(self.base_representation,
+                                                   type(base)))
+
+    def to_cartesian(self, base):
+        """Convert the offset to 3D rectangular cartesian coordinates.
+
+        Parameters
+        ----------
+        base : instance of ``self.base_representation``
+             The points for which the offsets are to converted: each of the
+             components is multiplied by its unit vectors and scale factors.
+        """
+        self._check_base(base)
+        base_e = base.unit_vectors()
+        base_sf = base.scale_factors()
+        return functools.reduce(
+            operator.add, (getattr(self, 'd_' + component) *
+                           base_sf[component] * e
+                           for component, e in six.iteritems(base_e)))
+
+    @sharedmethod
+    def from_cartesian(self, other, base):
+        """Interpret 3D rectangular cartesian coordinates as offsets.
+
+        Parameters
+        ----------
+        base : instance of ``self.base_representation``
+            Base relative to which the offsets are defined.
+        """
+        cls = self if isinstance(self, type) else type(self)
+        self._check_base(base)
+        base_e = base.unit_vectors()
+        base_sf = base.scale_factors()
+        return cls(*(other.dot(e / base_sf[component])
+                     for component, e in six.iteritems(base_e)))
+
+    def _scale_operation(self, op, *args):
+        scaled_attrs = [op(getattr(self, c), *args) for c in self.components]
+        return self.__class__(*scaled_attrs, copy=False)
+
+    def _combine_operation(self, op, other, reverse=False):
+        try:
+            self_cartesian = self.to_cartesian(other)
+        except TypeError:
+            return NotImplemented
+
+        return other._combine_operation(op, self_cartesian, not reverse)
+
+    def norm(self, base=None):
+        """Vector norm.
+
+        The norm is the standard Frobenius norm, i.e., the square root of the
+        sum of the squares of all components with non-angular units.
+
+        Parameters
+        ----------
+        base : instance of ``self.base_representation``
+            Base relative to which the offsets are defined, which is required
+            to calculate the physical size of the offset.
+
+        Returns
+        -------
+        norm : `astropy.units.Quantity`
+            Vector norm, with the same shape as the representation.
+        """
+        return self.to_cartesian(base).norm()
+
+    # ensure components behave as if they were properties.
+    def __getattr__(self, attr):
+        if attr in self.attr_classes:
+            return getattr(self, '_' + attr)
+
+        return self.__getattribute__(attr)
+
+    def __setattr__(self, attr, value):
+        if attr in self.attr_classes:
+            raise AttributeError("can't set attribute.")
+        return super(BaseOffset, self).__setattr__(attr, value)
+
+    def __delattr__(self, attr):
+        if attr in self.attr_classes:
+            raise AttributeError("can't delete attribute.")
+        return super(BaseOffset, self).__delattr__(attr)
+
+
+class SphericalOffset(BaseOffset):
+    base_representation = SphericalRepresentation

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -19,7 +19,7 @@ from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..extern import six
 from ..utils import ShapedLikeNDArray, classproperty
-from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12, override__dir__
+from ..utils.compat import NUMPY_LT_1_8, NUMPY_LT_1_12
 from ..utils.compat.numpy import broadcast_arrays, broadcast_to
 
 __all__ = ["BaseRepresentation", "CartesianRepresentation",
@@ -270,6 +270,13 @@ class RepresentationBase(ShapedLikeNDArray):
             unitstr, prefixstr, arrstr)
 
 
+def _make_getter(component):
+    component = '_' + component
+    def get_component(self):
+        return getattr(self, component)
+    return get_component
+
+
 # Need to subclass ABCMeta rather than type, so that this meta class can be
 # combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
 # "TypeError: metaclass conflict: the metaclass of a derived class must be a
@@ -292,6 +299,14 @@ class MetaBaseRepresentation(abc.ABCMeta):
             raise ValueError("Representation class {0} already defined".format(repr_name))
 
         REPRESENTATION_CLASSES[repr_name] = cls
+
+        # define getters for any component that does not yet have one.
+        for component in cls.attr_classes:
+            if not hasattr(cls, component):
+                setattr(cls, component,
+                        property(_make_getter(component),
+                                 doc=("The '{0}' component of the points(s)."
+                                      .format(component))))
 
 
 @six.add_metaclass(MetaBaseRepresentation)
@@ -497,27 +512,6 @@ class CartesianRepresentation(BaseRepresentation):
         if not (self._x.unit.physical_type ==
                 self._y.unit.physical_type == self._z.unit.physical_type):
             raise u.UnitsError("x, y, and z should have matching physical types")
-
-    @property
-    def x(self):
-        """
-        The x component of the point(s).
-        """
-        return self._x
-
-    @property
-    def y(self):
-        """
-        The y component of the point(s).
-        """
-        return self._y
-
-    @property
-    def z(self):
-        """
-        The z component of the point(s).
-        """
-        return self._z
 
     def unit_vectors(self):
         """Cartesian unit vectors in the direction of each component.
@@ -770,6 +764,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
         super(UnitSphericalRepresentation,
               self).__init__(lon, lat, copy=copy)
 
+    # Could let the metaclass define these automatically, but good to have
+    # a bit clearer docstrings.
     @property
     def lon(self):
         """
@@ -1440,6 +1436,13 @@ class MetaBaseDifferential(abc.ABCMeta):
             cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
                                             for c in base_attr_classes])
 
+        for component in cls.attr_classes:
+            if not hasattr(cls, component):
+                setattr(cls, component,
+                        property(_make_getter(component),
+                                 doc=("Component '{0}' of the Differential."
+                                      .format(component))))
+
 
 @six.add_metaclass(MetaBaseDifferential)
 class BaseDifferential(RepresentationBase):
@@ -1559,27 +1562,6 @@ class BaseDifferential(RepresentationBase):
             Vector norm, with the same shape as the representation.
         """
         return self.to_cartesian(base).norm()
-
-    # ensure components behave as if they were properties.
-    @override__dir__
-    def __dir__(self):
-        return self.components
-
-    def __getattr__(self, attr):
-        if attr in self.attr_classes:
-            return getattr(self, '_' + attr)
-
-        return self.__getattribute__(attr)
-
-    def __setattr__(self, attr, value):
-        if attr in self.attr_classes:
-            raise AttributeError("can't set attribute.")
-        return super(BaseDifferential, self).__setattr__(attr, value)
-
-    def __delattr__(self, attr):
-        if attr in self.attr_classes:
-            raise AttributeError("can't delete attribute.")
-        return super(BaseDifferential, self).__delattr__(attr)
 
 
 class CartesianDifferential(BaseDifferential):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -139,26 +139,6 @@ class TestSphericalRepresentation(object):
                                          distance=[1, 2] * u.kpc)
         assert exc.value.args[0] == "Input parameters lon, lat, and distance cannot be broadcast"
 
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = SphericalRepresentation(lon='2h6m3.3s',
-                                         lat='0.1rad',
-                                         distance=1 * u.kpc)
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = SphericalRepresentation(lon=[8 * u.hourangle, 135 * u.deg],
-                                         lat=[5 * u.deg, (6 * np.pi / 180) * u.rad],
-                                         distance=1 * u.kpc)
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
     def test_readonly(self):
 
         s1 = SphericalRepresentation(lon=8 * u.hourangle,
@@ -275,23 +255,6 @@ class TestUnitSphericalRepresentation(object):
             s1 = UnitSphericalRepresentation(lon=[8, 9, 10] * u.hourangle,
                                              lat=[5, 6] * u.deg)
         assert exc.value.args[0] == "Input parameters lon and lat cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = UnitSphericalRepresentation(lon='2h6m3.3s', lat='0.1rad')
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = UnitSphericalRepresentation(lon=[8 * u.hourangle, 135 * u.deg],
-                                             lat=[5 * u.deg, (6 * np.pi / 180) * u.rad])
-        assert exc.value.args[0] == "lon should be a Quantity, Angle, or Longitude"
 
     def test_readonly(self):
 
@@ -411,24 +374,6 @@ class TestPhysicsSphericalRepresentation(object):
                                                 theta=[5, 6] * u.deg,
                                                 r=[1, 2] * u.kpc)
         assert exc.value.args[0] == "Input parameters phi, theta, and r cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_init_str(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = PhysicsSphericalRepresentation(phi='2h6m3.3s', theta='0.1rad', r=1 * u.kpc)
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = PhysicsSphericalRepresentation(phi=[8 * u.hourangle, 135 * u.deg],
-                                                theta=[5 * u.deg, (6 * np.pi / 180) * u.rad],
-                                                r=[1. * u.kpc, 500 * u.pc])
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
 
     def test_readonly(self):
 
@@ -608,18 +553,6 @@ class TestCartesianRepresentation(object):
             s1 = CartesianRepresentation(x=[1, 2] * u.kpc, y=[3, 4] * u.kpc, z=[5, 6, 7] * u.kpc)
         assert exc.value.args[0] == "Input parameters x, y, and z cannot be broadcast"
 
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = CartesianRepresentation(x=[1 * u.kpc, 2 * u.Mpc],
-                                         y=[3 * u.kpc, 4 * u.pc],
-                                         z=[5. * u.cm, 6 * u.m])
-        assert exc.value.args[0].startswith("x should")
-
     def test_readonly(self):
 
         s1 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)
@@ -782,18 +715,6 @@ class TestCylindricalRepresentation(object):
         with pytest.raises(ValueError) as exc:
             s1 = CylindricalRepresentation(rho=[1, 2] * u.kpc, phi=[3, 4] * u.deg, z=[5, 6, 7] * u.kpc)
         assert exc.value.args[0] == "Input parameters rho, phi, and z cannot be broadcast"
-
-    # We deliberately disallow anything that is not directly a Quantity in
-    # these low-level classes, so we now check that initializing from a
-    # string or mixed unit lists raises a TypeError.
-
-    def test_mixed_units(self):
-
-        with pytest.raises(TypeError) as exc:
-            s1 = CylindricalRepresentation(rho=[1 * u.kpc, 2 * u.Mpc],
-                                           phi=[3 * u.deg, 4 * u.arcmin],
-                                           z=[5. * u.cm, 6 * u.m])
-        assert exc.value.args[0] == "phi should be a Quantity or Angle"
 
     def test_readonly(self):
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -37,6 +37,9 @@ def teardown_function(func):
 
 class TestSphericalRepresentation(object):
 
+    def test_name(self):
+        assert SphericalRepresentation.get_name() == 'spherical'
+
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
             s = SphericalRepresentation()
@@ -187,6 +190,9 @@ class TestSphericalRepresentation(object):
 
 class TestUnitSphericalRepresentation(object):
 
+    def test_name(self):
+        assert UnitSphericalRepresentation.get_name() == 'unitspherical'
+
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
             s = UnitSphericalRepresentation()
@@ -290,6 +296,9 @@ class TestUnitSphericalRepresentation(object):
 
 
 class TestPhysicsSphericalRepresentation(object):
+
+    def test_name(self):
+        assert PhysicsSphericalRepresentation.get_name() == 'physicsspherical'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -416,6 +425,9 @@ class TestPhysicsSphericalRepresentation(object):
 
 
 class TestCartesianRepresentation(object):
+
+    def test_name(self):
+        assert CartesianRepresentation.get_name() == 'cartesian'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -644,6 +656,9 @@ class TestCartesianRepresentation(object):
 
 
 class TestCylindricalRepresentation(object):
+
+    def test_name(self):
+        assert CylindricalRepresentation.get_name() == 'cylindrical'
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -26,6 +26,8 @@ from ..representation import (REPRESENTATION_CLASSES,
                               _combine_xyz)
 
 
+# Preserve the original REPRESENTATION_CLASSES dict so that importing
+#   the test file doesn't add a persistent test subclass (LogDRepresentation)
 def setup_function(func):
     func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
 
@@ -39,6 +41,7 @@ class TestSphericalRepresentation(object):
 
     def test_name(self):
         assert SphericalRepresentation.get_name() == 'spherical'
+        assert SphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -192,6 +195,7 @@ class TestUnitSphericalRepresentation(object):
 
     def test_name(self):
         assert UnitSphericalRepresentation.get_name() == 'unitspherical'
+        assert UnitSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -299,6 +303,7 @@ class TestPhysicsSphericalRepresentation(object):
 
     def test_name(self):
         assert PhysicsSphericalRepresentation.get_name() == 'physicsspherical'
+        assert PhysicsSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -428,6 +433,7 @@ class TestCartesianRepresentation(object):
 
     def test_name(self):
         assert CartesianRepresentation.get_name() == 'cartesian'
+        assert CartesianRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -659,6 +665,7 @@ class TestCylindricalRepresentation(object):
 
     def test_name(self):
         assert CylindricalRepresentation.get_name() == 'cylindrical'
+        assert CylindricalRepresentation.get_name() in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from copy import deepcopy
+from collections import OrderedDict
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -16,6 +17,7 @@ from ...utils import isiterable
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
 from ..representation import (REPRESENTATION_CLASSES,
+                              BaseRepresentation,
                               SphericalRepresentation,
                               UnitSphericalRepresentation,
                               CartesianRepresentation,
@@ -909,7 +911,6 @@ def test_representation_str():
 
 
 def test_subclass_representation():
-    from collections import OrderedDict
     from ..builtin_frames import ICRS
 
     class Longitude180(Longitude):
@@ -935,3 +936,59 @@ def test_subclass_representation():
     assert c.ra.unit is u.deg
     assert c.dec.value == -2
     assert c.dec.unit is u.deg
+
+
+def test_minimal_subclass():
+    # Basically to check what we document works;
+    # see doc/coordinates/representations.rst
+    class LogDRepresentation(BaseRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude),
+                                    ('lat', Latitude),
+                                    ('logd', u.Dex)])
+
+        def to_cartesian(self):
+            d = self.logd.physical
+            x = d * np.cos(self.lat) * np.cos(self.lon)
+            y = d * np.cos(self.lat) * np.sin(self.lon)
+            z = d * np.sin(self.lat)
+            return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+
+        @classmethod
+        def from_cartesian(cls, cart):
+            s = np.hypot(cart.x, cart.y)
+            r = np.hypot(s, cart.z)
+            lon = np.arctan2(cart.y, cart.x)
+            lat = np.arctan2(cart.z, s)
+            return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=False)
+
+    ld1 = LogDRepresentation(90.*u.deg, 0.*u.deg, 1.*u.dex(u.kpc))
+    ld2 = LogDRepresentation(lon=90.*u.deg, lat=0.*u.deg, logd=1.*u.dex(u.kpc))
+    assert np.all(ld1.lon==ld2.lon)
+    assert np.all(ld1.lat==ld2.lat)
+    assert np.all(ld1.logd==ld2.logd)
+    c = ld1.to_cartesian()
+    assert_allclose_quantity(c.xyz, [0., 10., 0.] * u.kpc, atol=1.*u.npc)
+    ld3 = LogDRepresentation.from_cartesian(c)
+    assert np.all(ld3.lon==ld2.lon)
+    assert np.all(ld3.lat==ld2.lat)
+    assert np.all(ld3.logd==ld2.logd)
+    s = ld1.represent_as(SphericalRepresentation)
+    assert_allclose_quantity(s.lon, ld1.lon)
+    assert_allclose_quantity(s.distance, 10.*u.kpc)
+    assert_allclose_quantity(s.lat, ld1.lat)
+
+    with pytest.raises(TypeError):
+        LogDRepresentation(0.*u.deg, 1.*u.deg)
+    with pytest.raises(TypeError):
+        LogDRepresentation(0.*u.deg, 1.*u.deg, 1.*u.dex(u.kpc), lon=1.*u.deg)
+    with pytest.raises(TypeError):
+        LogDRepresentation(0.*u.deg, 1.*u.deg, 1.*u.dex(u.kpc), True, False)
+    with pytest.raises(TypeError):
+        LogDRepresentation(0.*u.deg, 1.*u.deg, 1.*u.dex(u.kpc), foo='bar')
+
+    with pytest.raises(ValueError):
+        # check we cannot redefine an existing class.
+        class LogDRepresentation(BaseRepresentation):
+            attr_classes = OrderedDict([('lon', Longitude),
+                                        ('lat', Latitude),
+                                        ('logr', u.Dex)])

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -22,7 +22,8 @@ from ..representation import (REPRESENTATION_CLASSES,
                               UnitSphericalRepresentation,
                               CartesianRepresentation,
                               CylindricalRepresentation,
-                              PhysicsSphericalRepresentation)
+                              PhysicsSphericalRepresentation,
+                              _combine_xyz)
 
 
 def setup_function(func):
@@ -992,3 +993,31 @@ def test_minimal_subclass():
             attr_classes = OrderedDict([('lon', Longitude),
                                         ('lat', Latitude),
                                         ('logr', u.Dex)])
+
+def test_combine_xyz():
+
+    x,y,z = np.arange(27).reshape(3, 9) * u.kpc
+    xyz = _combine_xyz(x, y, z, xyz_axis=0)
+    assert xyz.shape == (3, 9)
+    assert np.all(xyz[0] == x)
+    assert np.all(xyz[1] == y)
+    assert np.all(xyz[2] == z)
+
+    x,y,z = np.arange(27).reshape(3, 3, 3) * u.kpc
+    xyz = _combine_xyz(x, y, z, xyz_axis=0)
+    assert xyz.ndim == 3
+    assert np.all(xyz[0] == x)
+    assert np.all(xyz[1] == y)
+    assert np.all(xyz[2] == z)
+
+    xyz = _combine_xyz(x, y, z, xyz_axis=1)
+    assert xyz.ndim == 3
+    assert np.all(xyz[:,0] == x)
+    assert np.all(xyz[:,1] == y)
+    assert np.all(xyz[:,2] == z)
+
+    xyz = _combine_xyz(x, y, z, xyz_axis=-1)
+    assert xyz.ndim == 3
+    assert np.all(xyz[...,0] == x)
+    assert np.all(xyz[...,1] == y)
+    assert np.all(xyz[...,2] == z)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -7,16 +7,20 @@ import numpy as np
 from ... import units as u
 from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CylindricalRepresentation, SphericalRepresentation,
-                UnitSphericalRepresentation, Longitude, Latitude)
+                UnitSphericalRepresentation, SphericalOffset,
+                Longitude, Latitude)
 from ..angle_utilities import angular_separation
+from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import pytest, assert_quantity_allclose
 
 
 def assert_representation_allclose(actual, desired, rtol=1.e-7, atol=None,
                                    **kwargs):
-    assert_quantity_allclose(actual.to_cartesian().xyz,
-                             desired.to_cartesian().xyz,
-                             rtol, atol, **kwargs)
+    actual_xyz = actual.to_cartesian().get_xyz(xyz_axis=-1)
+    desired_xyz = desired.to_cartesian().get_xyz(xyz_axis=-1)
+    actual_xyz, desired_xyz = broadcast_arrays(actual_xyz, desired_xyz,
+                                               subok=True)
+    assert_quantity_allclose(actual_xyz, desired_xyz, rtol, atol, **kwargs)
 
 
 def representation_equal(first, second):
@@ -516,3 +520,124 @@ class TestUnitVectorsAndScales():
         assert_quantity_allclose(s_z.z, s.z + 1.*u.pc)
         s_z2 = s + 1. * u.pc * sf['z'] * e['z']
         assert_representation_allclose(s_z2, s_z)
+
+
+class TestSphericalOffset():
+
+    def setup(self):
+        s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                    lat=[0., -30., 85.] * u.deg,
+                                    distance=[1, 2, 3] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        o_lon = SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_lonc = o_lon.to_cartesian(base=s)
+        o_lon2 = SphericalOffset.from_cartesian(o_lonc, base=s)
+        assert_quantity_allclose(o_lon.d_lon, o_lon2.d_lon, atol=1.*u.narcsec)
+        assert_quantity_allclose(o_lon.d_lat, o_lon2.d_lat, atol=1.*u.narcsec)
+        assert_quantity_allclose(o_lon.d_distance, o_lon2.d_distance,
+                                 atol=1.*u.npc)
+        # simple check by hand for first element.
+        assert_quantity_allclose(o_lonc[0].xyz,
+                                 [0., np.pi/180./3600., 0.]*u.kpc)
+        # check all using unit vectors and scale factors.
+        s_lon = s + 1.*u.arcsec * sf['lon'] * e['lon']
+        assert_representation_allclose(o_lonc, s_lon - s, atol=1e-10*u.kpc)
+
+        o_lat = SphericalOffset(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
+        o_latc = o_lat.to_cartesian(base=s)
+        assert_quantity_allclose(o_latc[0].xyz,
+                                 [0., 0., np.pi/180./3600.]*u.kpc)
+        s_lat = s + 1.*u.arcsec * sf['lat'] * e['lat']
+        assert_representation_allclose(o_latc, s_lat - s, atol=1e-10*u.kpc)
+        s_lat2 = s + o_lat
+        assert_representation_allclose(s_lat2, s_lat, atol=1e-10*u.kpc)
+
+        o_distance = SphericalOffset(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
+        o_distancec = o_distance.to_cartesian(base=s)
+        assert_quantity_allclose(o_distancec[0].xyz,
+                                 [1e-6, 0., 0.]*u.kpc)
+        s_distance = s + 1.*u.mpc * sf['distance'] * e['distance']
+        assert_representation_allclose(o_distancec, s_distance - s,
+                                       atol=1e-10*u.kpc)
+        s_distance2 = s + o_distance
+        assert_representation_allclose(s_distance2, s_distance)
+
+    def test_offset_arithmetic(self):
+        s = self.s
+
+        o_lon = SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_lon_by_2 = o_lon / 2.
+        assert_representation_allclose(o_lon_by_2.to_cartesian(s) * 2.,
+                                       o_lon.to_cartesian(s), atol=1e-10*u.kpc)
+        assert_representation_allclose(s + o_lon, s + 2 * o_lon_by_2,
+                                       atol=1e-10*u.kpc)
+        o_lon2 = SphericalOffset(1.*u.mas/u.yr, 0.*u.mas/u.yr, 0.*u.km/u.s)
+        assert_quantity_allclose(o_lon2.norm(s)[0], 4.74*u.km/u.s,
+                                 atol=0.01*u.km/u.s)
+        assert_representation_allclose(o_lon2.to_cartesian(s) * 1000.*u.yr,
+                                       o_lon.to_cartesian(s), atol=1e-10*u.kpc)
+        s_off = s + o_lon
+        s_off2 = s + o_lon2 * 1000.*u.yr
+        assert_representation_allclose(s_off, s_off2, atol=1e-10*u.kpc)
+
+        s_off_big = s + o_lon * 1e5 * u.radian/u.arcsec
+
+        assert_representation_allclose(
+            s_off_big, SphericalRepresentation(s.lon + 90.*u.deg, 0.*u.deg,
+                                               1e5*s.distance*np.cos(s.lat)),
+            atol=5.*u.kpc)
+
+        o_lon3c = CartesianRepresentation(0., 4.74047, 0., unit=u.km/u.s)
+        o_lon3 = SphericalOffset.from_cartesian(o_lon3c, base=s)
+        assert_quantity_allclose(o_lon3.d_lon[0], 1.*u.mas/u.yr,
+                                 atol=1.*u.uas/u.yr)
+        s_off_big2 = s + o_lon3 * 1e5 * u.yr * u.radian/u.mas
+        assert_representation_allclose(
+            s_off_big2, SphericalRepresentation(90.*u.deg, 0.*u.deg,
+                                                1e5*u.kpc), atol=5.*u.kpc)
+
+    def test_offset_init_errors(self):
+        s = self.s
+        with pytest.raises(TypeError):
+            SphericalOffset(1.*u.arcsec, 0., 0.)
+        with pytest.raises(TypeError):
+            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc, False, False)
+        with pytest.raises(TypeError):
+            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
+                            copy=False, d_lon=0.*u.arcsec)
+        with pytest.raises(TypeError):
+            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
+                            copy=False, flying='circus')
+        with pytest.raises(ValueError):
+            SphericalOffset(np.ones(2)*u.arcsec,
+                            np.zeros(3)*u.arcsec, np.zeros(2)*u.kpc)
+        with pytest.raises(u.UnitsError):
+            SphericalOffset(1.*u.arcsec, 1.*u.s, 0.*u.kpc)
+        with pytest.raises(u.UnitsError):
+            SphericalOffset(1.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
+        o = SphericalOffset(1.*u.arcsec, 1.*u.arcsec, 0.*u.km/u.s)
+        with pytest.raises(u.UnitsError):
+            o.to_cartesian(s)
+        with pytest.raises(AttributeError):
+            o.d_lon = 0.*u.arcsec
+        with pytest.raises(AttributeError):
+            del o.d_lon
+
+        o = SphericalOffset(1.*u.arcsec, 1.*u.arcsec, 0.*u.km)
+        with pytest.raises(TypeError):
+            o.to_cartesian()
+        c = CartesianRepresentation(10., 0., 0., unit=u.km)
+        with pytest.raises(TypeError):
+            SphericalOffset.to_cartesian(c)
+        with pytest.raises(TypeError):
+            SphericalOffset.from_cartesian(c)
+        with pytest.raises(TypeError):
+            SphericalOffset.from_cartesian(c, SphericalRepresentation)
+        with pytest.raises(TypeError):
+            SphericalOffset.from_cartesian(c, c)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -10,7 +10,7 @@ from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 UnitSphericalRepresentation, SphericalDifferential,
                 CartesianDifferential, UnitSphericalDifferential,
                 PhysicsSphericalDifferential, CylindricalDifferential,
-                Longitude, Latitude)
+                RadialRepresentation, RadialDifferential, Longitude, Latitude)
 from ..angle_utilities import angular_separation
 from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import pytest, assert_quantity_allclose
@@ -612,6 +612,9 @@ class TestSphericalDifferential():
             s_off_big2, SphericalRepresentation(90.*u.deg, 0.*u.deg,
                                                 1e5*u.kpc), atol=5.*u.kpc)
 
+        with pytest.raises(TypeError):
+            o_lon - s
+
     def test_differential_init_errors(self):
         s = self.s
         with pytest.raises(TypeError):
@@ -742,6 +745,35 @@ class TestUnitSphericalDifferential():
         expected0 = SphericalRepresentation(90.*u.deg, 0.*u.deg,
                                             1e5*u.one)
         assert_representation_allclose(s_off_big2[0], expected0, atol=5.*u.one)
+
+
+class TestRadialDifferential():
+    def setup(self):
+        s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                    lat=[0., -30., 85.] * u.deg,
+                                    distance=[1, 2, 3] * u.kpc)
+        self.s = s
+        self.r = s.represent_as(RadialRepresentation)
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_differentials(self):
+        r, s, e, sf = self.r, self.s, self.e, self.sf
+
+        o_distance = RadialDifferential(1.*u.mpc)
+        # Can be applied to RadialRepresentation, though not most useful.
+        r_distance = r + o_distance
+        assert_quantity_allclose(r_distance.distance,
+                                 r.distance + o_distance.d_distance)
+        # More sense to apply it relative to spherical representation.
+        o_distancec = o_distance.to_cartesian(base=s)
+        assert_quantity_allclose(o_distancec[0].xyz,
+                                 [1e-6, 0., 0.]*u.kpc, atol=1.*u.npc)
+        s_distance = s + 1.*u.mpc * sf['distance'] * e['distance']
+        assert_representation_allclose(o_distancec, s_distance - s,
+                                       atol=1*u.npc)
+        s_distance2 = s + o_distance
+        assert_representation_allclose(s_distance2, s_distance)
 
 
 class TestPhysicsSphericalDifferential():
@@ -896,3 +928,23 @@ class TestDifferentialConversion():
         s_off = s + so
         u_off = us + uo
         assert_representation_allclose(s_off, u_off * s.distance)
+
+    def test_combinations(self):
+        uo = UnitSphericalDifferential(2.*u.deg, 1.*u.deg)
+        ro = RadialDifferential(1.*u.mpc)
+        so1 = uo + ro
+        so1c = SphericalDifferential(uo.d_lon, uo.d_lat, ro.d_distance)
+        assert np.all(representation_equal(so1, so1c))
+        so2 = uo - ro
+        so2c = SphericalDifferential(uo.d_lon, uo.d_lat, -ro.d_distance)
+        assert np.all(representation_equal(so2, so2c))
+        so3 = so2 + ro
+        so3c = SphericalDifferential(uo.d_lon, uo.d_lat, 0.*u.kpc)
+        assert np.all(representation_equal(so3, so3c))
+        so4 = so1 + ro
+        so4c = SphericalDifferential(uo.d_lon, uo.d_lat, 2*ro.d_distance)
+        assert np.all(representation_equal(so4, so4c))
+        so5 = so1 - uo
+        so5c = SphericalDifferential(0*u.deg, 0.*u.deg, ro.d_distance)
+        assert np.all(representation_equal(so5, so5c))
+        assert_representation_allclose(self.s + (uo+ro), self.s+so1)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -833,6 +833,33 @@ class TestCylindricalOffset():
         assert_representation_allclose(s_z2, s_z)
 
 
+class TestCartesianOffset():
+    """Test copied from SphericalOffset, so less extensive."""
+    def setup(self):
+        s = CartesianRepresentation(x=[1, 2, 3] * u.kpc,
+                                    y=[2, 3, 1] * u.kpc,
+                                    z=[3, 1, 2] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        for d, offset in (('x', CartesianOffset(1.*u.pc, 0.*u.pc, 0.*u.pc)),
+                          ('y', CartesianOffset(0.*u.pc, 1.*u.pc, 0.*u.pc)),
+                          ('z', CartesianOffset(0.*u.pc, 0.*u.pc, 1.*u.pc))):
+            o_c = offset.tocartesian(base=s)
+            o_c2 = offset.to_cartesian()
+            assert np.all(representation_equal(o_c, o_c2))
+            assert all(np.all(getattr(offset, 'd_'+c) == getattr(o_c, c))
+                       for c in ('x', 'y', 'z'))
+            s_off = s + 1.*u.pc * sf[d] * e[d]
+            assert_representation_allclose(o_c, s_off - s, atol=1e-10*u.kpc)
+            s_off2 = s + offset
+            assert_representation_allclose(s_off2, s_off)
+
+
 class TestOffsetConversion():
     def setup(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -617,7 +617,7 @@ class TestSphericalDifferential():
 
     def test_differential_init_errors(self):
         s = self.s
-        with pytest.raises(TypeError):
+        with pytest.raises(u.UnitsError):
             SphericalDifferential(1.*u.arcsec, 0., 0.)
         with pytest.raises(TypeError):
             SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -831,3 +831,38 @@ class TestCylindricalOffset():
         assert_representation_allclose(o_zc, s_z - s, atol=1e-10*u.kpc)
         s_z2 = s + o_z
         assert_representation_allclose(s_z2, s_z)
+
+
+class TestOffsetConversion():
+    def setup(self):
+        s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                    lat=[0., -30., 85.] * u.deg,
+                                    distance=[1, 2, 3] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_convert_physics(self):
+        so = SphericalOffset(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+        po = so.represent_as(PhysicsSphericalOffset)
+        so2 = SphericalOffset.from_representation(po)
+        assert representation_equal(so, so2)
+        po2 = PhysicsSphericalOffset.from_representation(so)
+        assert representation_equal(po, po2)
+        s = self.s
+        p = s.represent_as(PhysicsSphericalRepresentation)
+        assert_representation_allclose(s + so, p + po)
+
+    def test_convert_unit_spherical(self):
+        s = self.s
+        us = s.represent_as(UnitSphericalRepresentation)
+        uo = UnitSphericalOffset(2.*u.deg, 1.*u.deg)
+        so = uo.represent_as(SphericalOffset, base=s)
+        assert_quantity_allclose(so.d_distance, 0.*u.kpc, atol=1.*u.npc)
+        uo2 = so.represent_as(UnitSphericalOffset)
+        assert_representation_allclose(uo.to_cartesian(us),
+                                       uo2.to_cartesian(us))
+
+        s_off = s + so
+        u_off = us + uo
+        assert_representation_allclose(s_off, u_off * s.distance)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -11,6 +11,7 @@ from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CartesianDifferential, UnitSphericalDifferential,
                 PhysicsSphericalDifferential, CylindricalDifferential,
                 RadialRepresentation, RadialDifferential, Longitude, Latitude)
+from ..representation import DIFFERENTIAL_CLASSES
 from ..angle_utilities import angular_separation
 from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import pytest, assert_quantity_allclose
@@ -545,6 +546,7 @@ class TestSphericalDifferential():
 
     def test_name(self):
         assert SphericalDifferential.get_name() == 'spherical'
+        assert SphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -682,6 +684,7 @@ class TestUnitSphericalDifferential():
 
     def test_name(self):
         assert UnitSphericalDifferential.get_name() == 'unitspherical'
+        assert UnitSphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -781,6 +784,7 @@ class TestRadialDifferential():
 
     def test_name(self):
         assert RadialDifferential.get_name() == 'radial'
+        assert RadialDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         r, s, e, sf = self.r, self.s, self.e, self.sf
@@ -819,6 +823,7 @@ class TestPhysicsSphericalDifferential():
 
     def test_name(self):
         assert PhysicsSphericalDifferential.get_name() == 'physicsspherical'
+        assert PhysicsSphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -874,6 +879,7 @@ class TestCylindricalDifferential():
 
     def test_name(self):
         assert CylindricalDifferential.get_name() == 'cylindrical'
+        assert CylindricalDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -924,6 +930,7 @@ class TestCartesianDifferential():
 
     def test_name(self):
         assert CartesianDifferential.get_name() == 'cartesian'
+        assert CartesianDifferential.get_name() in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -364,3 +364,155 @@ class TestArithmetic():
         expected = np.sin(sep)
         assert_quantity_allclose(u_cross_u_rev.norm(), expected,
                                  atol=1.e-10*u.one)
+
+
+class TestUnitVectorsAndScales():
+
+    @staticmethod
+    def check_unit_vectors(e):
+        for v in e.values():
+            assert type(v) is CartesianRepresentation
+            assert_quantity_allclose(v.norm(), 1. * u.one)
+        return e
+
+    @staticmethod
+    def check_scale_factors(sf, rep):
+        unit = rep.norm().unit
+        for c, f in sf.items():
+            assert type(f) is u.Quantity
+            assert (f.unit * getattr(rep, c).unit).is_equivalent(unit)
+
+    def test_spherical(self):
+        s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                    lat=[0., -30., 85.] * u.deg,
+                                    distance=[1, 2, 3] * u.kpc)
+        e = s.unit_vectors()
+        self.check_unit_vectors(e)
+        sf = s.scale_factors()
+        self.check_scale_factors(sf, s)
+
+        s_lon = s + s.distance * 1e-5 * np.cos(s.lat) * e['lon']
+        assert_quantity_allclose(s_lon.lon, s.lon + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        assert_quantity_allclose(s_lon.lat, s.lat, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_lon.distance, s.distance)
+        s_lon2 = s + 1e-5 * u.radian * sf['lon'] * e['lon']
+        assert_representation_allclose(s_lon2, s_lon)
+
+        s_lat = s + s.distance * 1e-5 * e['lat']
+        assert_quantity_allclose(s_lat.lon, s.lon)
+        assert_quantity_allclose(s_lat.lat, s.lat + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        assert_quantity_allclose(s_lon.distance, s.distance)
+        s_lat2 = s + 1.e-5 * u.radian * sf['lat'] * e['lat']
+        assert_representation_allclose(s_lat2, s_lat)
+
+        s_distance = s + 1. * u.pc * e['distance']
+        assert_quantity_allclose(s_distance.lon, s.lon, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_distance.lat, s.lat, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_distance.distance, s.distance + 1.*u.pc)
+        s_distance2 = s + 1. * u.pc * sf['distance'] * e['distance']
+        assert_representation_allclose(s_distance2, s_distance)
+
+    def test_unit_spherical(self):
+        s = UnitSphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                        lat=[0., -30., 85.] * u.deg)
+
+        e = s.unit_vectors()
+        self.check_unit_vectors(e)
+        sf = s.scale_factors()
+        self.check_scale_factors(sf, s)
+
+        s_lon = s + 1e-5 * np.cos(s.lat) * e['lon']
+        assert_quantity_allclose(s_lon.lon, s.lon + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        assert_quantity_allclose(s_lon.lat, s.lat, atol=1e-10*u.rad)
+        s_lon2 = s + 1e-5 * u.radian * sf['lon'] * e['lon']
+        assert_representation_allclose(s_lon2, s_lon)
+
+        s_lat = s + 1e-5 * e['lat']
+        assert_quantity_allclose(s_lat.lon, s.lon)
+        assert_quantity_allclose(s_lat.lat, s.lat + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        s_lat2 = s + 1.e-5 * u.radian * sf['lat'] * e['lat']
+        assert_representation_allclose(s_lat2, s_lat)
+
+    def test_physical_spherical(self):
+
+        s = PhysicsSphericalRepresentation(phi=[0., 6., 21.] * u.hourangle,
+                                           theta=[90., 120., 5.] * u.deg,
+                                           r=[1, 2, 3] * u.kpc)
+
+        e = s.unit_vectors()
+        self.check_unit_vectors(e)
+        sf = s.scale_factors()
+        self.check_scale_factors(sf, s)
+
+        s_phi = s + s.r * 1e-5 * np.sin(s.theta) * e['phi']
+        assert_quantity_allclose(s_phi.phi, s.phi + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        assert_quantity_allclose(s_phi.theta, s.theta, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_phi.r, s.r)
+        s_phi2 = s + 1e-5 * u.radian * sf['phi'] * e['phi']
+        assert_representation_allclose(s_phi2, s_phi)
+
+        s_theta = s + s.r * 1e-5 * e['theta']
+        assert_quantity_allclose(s_theta.phi, s.phi)
+        assert_quantity_allclose(s_theta.theta, s.theta + 1e-5*u.rad,
+                                 atol=1e-10*u.rad)
+        assert_quantity_allclose(s_theta.r, s.r)
+        s_theta2 = s + 1.e-5 * u.radian * sf['theta'] * e['theta']
+        assert_representation_allclose(s_theta2, s_theta)
+
+        s_r = s + 1. * u.pc * e['r']
+        assert_quantity_allclose(s_r.phi, s.phi, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_r.theta, s.theta, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_r.r, s.r + 1.*u.pc)
+        s_r2 = s + 1. * u.pc * sf['r'] * e['r']
+        assert_representation_allclose(s_r2, s_r)
+
+    def test_cartesian(self):
+
+        s = CartesianRepresentation(x=[1, 2, 3] * u.pc,
+                                    y=[2, 3, 4] * u.Mpc,
+                                    z=[3, 4, 5] * u.kpc)
+
+        e = s.unit_vectors()
+        sf = s.scale_factors()
+        for v, expected in zip(e.values(), ([1., 0., 0.] * u.one,
+                                            [0., 1., 0.] * u.one,
+                                            [0., 0., 1.] * u.one)):
+            assert np.all(v.get_xyz(xyz_axis=-1) == expected)
+        for f in sf.values():
+            assert np.all(f == 1.*u.one)
+
+    def test_cylindrical(self):
+
+        s = CylindricalRepresentation(rho=[1, 2, 3] * u.pc,
+                                      phi=[0., 90., -45.] * u.deg,
+                                      z=[3, 4, 5] * u.kpc)
+        e = s.unit_vectors()
+        self.check_unit_vectors(e)
+        sf = s.scale_factors()
+        self.check_scale_factors(sf, s)
+
+        s_rho = s + 1. * u.pc * e['rho']
+        assert_quantity_allclose(s_rho.rho, s.rho + 1.*u.pc)
+        assert_quantity_allclose(s_rho.phi, s.phi)
+        assert_quantity_allclose(s_rho.z, s.z)
+        s_rho2 = s + 1. * u.pc * sf['rho'] * e['rho']
+        assert_representation_allclose(s_rho2, s_rho)
+
+        s_phi = s + s.rho * 1e-5 * e['phi']
+        assert_quantity_allclose(s_phi.rho, s.rho)
+        assert_quantity_allclose(s_phi.phi, s.phi + 1e-5*u.rad)
+        assert_quantity_allclose(s_phi.z, s.z)
+        s_phi2 = s + 1e-5 * u.radian * sf['phi'] * e['phi']
+        assert_representation_allclose(s_phi2, s_phi)
+
+        s_z = s + 1. * u.pc * e['z']
+        assert_quantity_allclose(s_z.rho, s.rho)
+        assert_quantity_allclose(s_z.phi, s.phi, atol=1e-10*u.rad)
+        assert_quantity_allclose(s_z.z, s.z + 1.*u.pc)
+        s_z2 = s + 1. * u.pc * sf['z'] * e['z']
+        assert_representation_allclose(s_z2, s_z)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -543,6 +543,9 @@ class TestSphericalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert SphericalDifferential.get_name() == 'spherical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -677,6 +680,9 @@ class TestUnitSphericalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert UnitSphericalDifferential.get_name() == 'unitspherical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -773,6 +779,9 @@ class TestRadialDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert RadialDifferential.get_name() == 'radial'
+
     def test_simple_differentials(self):
         r, s, e, sf = self.r, self.s, self.e, self.sf
 
@@ -807,6 +816,9 @@ class TestPhysicsSphericalDifferential():
         self.s = s
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
+
+    def test_name(self):
+        assert PhysicsSphericalDifferential.get_name() == 'physicsspherical'
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -860,6 +872,9 @@ class TestCylindricalDifferential():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_name(self):
+        assert CylindricalDifferential.get_name() == 'cylindrical'
+
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
@@ -906,6 +921,9 @@ class TestCartesianDifferential():
         self.s = s
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
+
+    def test_name(self):
+        assert CartesianDifferential.get_name() == 'cartesian'
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -443,6 +443,16 @@ class TestUnitVectorsAndScales():
         s_lat2 = s + 1.e-5 * u.radian * sf['lat'] * e['lat']
         assert_representation_allclose(s_lat2, s_lat)
 
+    def test_radial(self):
+        r = RadialRepresentation(10.*u.kpc)
+        with pytest.raises(NotImplementedError):
+            r.unit_vectors()
+        sf = r.scale_factors()
+        assert np.all(sf['distance'] == 1.*u.one)
+        assert np.all(r.norm() == r.distance)
+        with pytest.raises(TypeError):
+            r + r
+
     def test_physical_spherical(self):
 
         s = PhysicsSphericalRepresentation(phi=[0., 6., 21.] * u.hourangle,
@@ -614,6 +624,8 @@ class TestSphericalDifferential():
 
         with pytest.raises(TypeError):
             o_lon - s
+        with pytest.raises(TypeError):
+            s.to_cartesian() + o_lon
 
     def test_differential_init_errors(self):
         s = self.s
@@ -746,6 +758,10 @@ class TestUnitSphericalDifferential():
                                             1e5*u.one)
         assert_representation_allclose(s_off_big2[0], expected0, atol=5.*u.one)
 
+    def test_differential_init_errors(self):
+        with pytest.raises(u.UnitsError):
+            UnitSphericalDifferential(0.*u.deg, 10.*u.deg/u.yr)
+
 
 class TestRadialDifferential():
     def setup(self):
@@ -765,10 +781,16 @@ class TestRadialDifferential():
         r_distance = r + o_distance
         assert_quantity_allclose(r_distance.distance,
                                  r.distance + o_distance.d_distance)
+        r_distance2 = o_distance + r
+        assert_quantity_allclose(r_distance2.distance,
+                                 r.distance + o_distance.d_distance)
         # More sense to apply it relative to spherical representation.
         o_distancec = o_distance.to_cartesian(base=s)
         assert_quantity_allclose(o_distancec[0].xyz,
                                  [1e-6, 0., 0.]*u.kpc, atol=1.*u.npc)
+        o_recover = RadialDifferential.from_cartesian(o_distancec, base=s)
+        assert_quantity_allclose(o_recover.d_distance, o_distance.d_distance)
+
         s_distance = s + 1.*u.mpc * sf['distance'] * e['distance']
         assert_representation_allclose(o_distancec, s_distance - s,
                                        atol=1*u.npc)
@@ -823,6 +845,10 @@ class TestPhysicsSphericalDifferential():
         s_r2 = s + o_r
         assert_representation_allclose(s_r2, s_r)
 
+    def test_differential_init_errors(self):
+        with pytest.raises(u.UnitsError):
+            PhysicsSphericalDifferential(1.*u.arcsec, 0., 0.)
+
 
 class TestCylindricalDifferential():
     """Test copied from SphericalDifferential, so less extensive."""
@@ -866,6 +892,10 @@ class TestCylindricalDifferential():
         s_z2 = s + o_z
         assert_representation_allclose(s_z2, s_z)
 
+    def test_differential_init_errors(self):
+        with pytest.raises(u.UnitsError):
+            CylindricalDifferential(1.*u.pc, 1.*u.arcsec, 3.*u.km/u.s)
+
 
 class TestCartesianDifferential():
     """Test copied from SphericalDifferential, so less extensive."""
@@ -880,19 +910,34 @@ class TestCartesianDifferential():
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        for d, differential in (
+        for d, differential in (  # test different inits while we're at it.
                 ('x', CartesianDifferential(1.*u.pc, 0.*u.pc, 0.*u.pc)),
-                ('y', CartesianDifferential(0.*u.pc, 1.*u.pc, 0.*u.pc)),
-                ('z', CartesianDifferential(0.*u.pc, 0.*u.pc, 1.*u.pc))):
+                ('y', CartesianDifferential([0., 1., 0.], unit=u.pc)),
+                ('z', CartesianDifferential(np.array([[0., 0., 1.]]) * u.pc,
+                                            xyz_axis=1))):
             o_c = differential.to_cartesian(base=s)
             o_c2 = differential.to_cartesian()
             assert np.all(representation_equal(o_c, o_c2))
             assert all(np.all(getattr(differential, 'd_'+c) == getattr(o_c, c))
                        for c in ('x', 'y', 'z'))
+            differential2 = CartesianDifferential.from_cartesian(o_c)
+            assert np.all(representation_equal(differential2, differential))
+            differential3 = CartesianDifferential.from_cartesian(o_c, base=o_c)
+            assert np.all(representation_equal(differential3, differential))
+
             s_off = s + 1.*u.pc * sf[d] * e[d]
             assert_representation_allclose(o_c, s_off - s, atol=1e-10*u.kpc)
             s_off2 = s + differential
             assert_representation_allclose(s_off2, s_off)
+
+    def test_init_failures(self):
+        with pytest.raises(ValueError):
+            CartesianDifferential(1.*u.kpc/u.s, 2.*u.kpc)
+        with pytest.raises(u.UnitsError):
+            CartesianDifferential(1.*u.kpc/u.s, 2.*u.kpc, 3.*u.kpc)
+        with pytest.raises(ValueError):
+            CartesianDifferential(1.*u.kpc, 2.*u.kpc, 3.*u.kpc, xyz_axis=1)
+
 
 
 class TestDifferentialConversion():
@@ -904,6 +949,25 @@ class TestDifferentialConversion():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
+    def test_represent_as_own_class(self):
+        so = SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+        so2 = so.represent_as(SphericalDifferential)
+        assert so2 is so
+
+    @pytest.mark.parametrize('r_cls', (SphericalRepresentation,
+                                       UnitSphericalRepresentation,
+                                       PhysicsSphericalRepresentation,
+                                       CylindricalRepresentation))
+    def test_represent_regular_class(self, r_cls):
+        so = SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+        r = so.represent_as(r_cls, base=self.s)
+        c = so.to_cartesian(self.s)
+        r_check = c.represent_as(r_cls)
+        assert np.all(representation_equal(r, r_check))
+        so2 = SphericalDifferential.from_representation(r, base=self.s)
+        so3 = SphericalDifferential.from_cartesian(r.to_cartesian(), self.s)
+        assert np.all(representation_equal(so2, so3))
+
     def test_convert_physics(self):
         so = SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
         po = so.represent_as(PhysicsSphericalDifferential)
@@ -911,23 +975,61 @@ class TestDifferentialConversion():
         assert representation_equal(so, so2)
         po2 = PhysicsSphericalDifferential.from_representation(so)
         assert representation_equal(po, po2)
+        so3 = po.represent_as(SphericalDifferential)
+        assert representation_equal(so, so3)
+
         s = self.s
         p = s.represent_as(PhysicsSphericalRepresentation)
         assert_representation_allclose(s + so, p + po)
 
-    def test_convert_unit_spherical(self):
+        suo = UnitSphericalDifferential.from_representation(so)
+        puo = UnitSphericalDifferential.from_representation(po)
+        assert representation_equal(suo, puo)
+        suo2 = so.represent_as(UnitSphericalDifferential)
+        puo2 = po.represent_as(UnitSphericalDifferential)
+        assert representation_equal(suo2, puo2)
+        assert representation_equal(puo, puo2)
+
+        sro = RadialDifferential.from_representation(so)
+        pro = RadialDifferential.from_representation(po)
+        assert representation_equal(sro, pro)
+        sro2 = so.represent_as(RadialDifferential)
+        pro2 = po.represent_as(RadialDifferential)
+        assert representation_equal(sro2, pro2)
+        assert representation_equal(pro, pro2)
+
+    def test_convert_unit_spherical_radial(self):
         s = self.s
         us = s.represent_as(UnitSphericalRepresentation)
+        rs = s.represent_as(RadialRepresentation)
+        assert_representation_allclose(rs * us, s)
+
         uo = UnitSphericalDifferential(2.*u.deg, 1.*u.deg)
         so = uo.represent_as(SphericalDifferential, base=s)
         assert_quantity_allclose(so.d_distance, 0.*u.kpc, atol=1.*u.npc)
         uo2 = so.represent_as(UnitSphericalDifferential)
         assert_representation_allclose(uo.to_cartesian(us),
                                        uo2.to_cartesian(us))
+        so1 = SphericalDifferential(2.*u.deg, 1.*u.deg, 5.*u.pc)
+        uo_r = so1.represent_as(UnitSphericalDifferential)
+        ro_r = so1.represent_as(RadialDifferential)
+        assert np.all(representation_equal(uo_r, uo))
+        assert np.all(representation_equal(ro_r, RadialDifferential(5.*u.pc)))
 
-        s_off = s + so
-        u_off = us + uo
-        assert_representation_allclose(s_off, u_off * s.distance)
+    def test_convert_cylindrial(self):
+        s = self.s
+        so = SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+        cyo = so.represent_as(CylindricalDifferential, base=s)
+        cy = s.represent_as(CylindricalRepresentation)
+        so1 = cyo.represent_as(SphericalDifferential, base=cy)
+        assert_representation_allclose(so.to_cartesian(s),
+                                       so1.to_cartesian(s))
+        cyo2 = CylindricalDifferential.from_representation(so, base=cy)
+        assert_representation_allclose(cyo2.to_cartesian(base=cy),
+                                       cyo.to_cartesian(base=cy))
+        so2 = SphericalDifferential.from_representation(cyo2, base=s)
+        assert_representation_allclose(so.to_cartesian(s),
+                                       so2.to_cartesian(s))
 
     def test_combinations(self):
         uo = UnitSphericalDifferential(2.*u.deg, 1.*u.deg)
@@ -935,6 +1037,7 @@ class TestDifferentialConversion():
         so1 = uo + ro
         so1c = SphericalDifferential(uo.d_lon, uo.d_lat, ro.d_distance)
         assert np.all(representation_equal(so1, so1c))
+
         so2 = uo - ro
         so2c = SphericalDifferential(uo.d_lon, uo.d_lat, -ro.d_distance)
         assert np.all(representation_equal(so2, so2c))

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -7,9 +7,10 @@ import numpy as np
 from ... import units as u
 from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CylindricalRepresentation, SphericalRepresentation,
-                UnitSphericalRepresentation, SphericalOffset,
-                CartesianOffset, UnitSphericalOffset, CylindricalOffset,
-                PhysicsSphericalOffset, Longitude, Latitude)
+                UnitSphericalRepresentation, SphericalDifferential,
+                CartesianDifferential, UnitSphericalDifferential,
+                PhysicsSphericalDifferential, CylindricalDifferential,
+                Longitude, Latitude)
 from ..angle_utilities import angular_separation
 from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import pytest, assert_quantity_allclose
@@ -523,7 +524,7 @@ class TestUnitVectorsAndScales():
         assert_representation_allclose(s_z2, s_z)
 
 
-class TestSphericalOffset():
+class TestSphericalDifferential():
     def setup(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                     lat=[0., -30., 85.] * u.deg,
@@ -532,12 +533,12 @@ class TestSphericalOffset():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
-    def test_simple_offsets(self):
+    def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        o_lon = SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_lon = SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
         o_lonc = o_lon.to_cartesian(base=s)
-        o_lon2 = SphericalOffset.from_cartesian(o_lonc, base=s)
+        o_lon2 = SphericalDifferential.from_cartesian(o_lonc, base=s)
         assert_quantity_allclose(o_lon.d_lon, o_lon2.d_lon, atol=1.*u.narcsec)
         assert_quantity_allclose(o_lon.d_lat, o_lon2.d_lat, atol=1.*u.narcsec)
         assert_quantity_allclose(o_lon.d_distance, o_lon2.d_distance,
@@ -551,7 +552,7 @@ class TestSphericalOffset():
         s_lon2 = s + o_lon
         assert_representation_allclose(s_lon2, s_lon, atol=1*u.npc)
 
-        o_lat = SphericalOffset(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
+        o_lat = SphericalDifferential(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
         o_latc = o_lat.to_cartesian(base=s)
         assert_quantity_allclose(o_latc[0].xyz,
                                  [0., 0., np.pi/180./3600.]*u.kpc,
@@ -561,7 +562,7 @@ class TestSphericalOffset():
         s_lat2 = s + o_lat
         assert_representation_allclose(s_lat2, s_lat, atol=1*u.npc)
 
-        o_distance = SphericalOffset(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
+        o_distance = SphericalDifferential(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
         o_distancec = o_distance.to_cartesian(base=s)
         assert_quantity_allclose(o_distancec[0].xyz,
                                  [1e-6, 0., 0.]*u.kpc, atol=1.*u.npc)
@@ -571,10 +572,10 @@ class TestSphericalOffset():
         s_distance2 = s + o_distance
         assert_representation_allclose(s_distance2, s_distance)
 
-    def test_offset_arithmetic(self):
+    def test_differential_arithmetic(self):
         s = self.s
 
-        o_lon = SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_lon = SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
         o_lon_by_2 = o_lon / 2.
         assert_representation_allclose(o_lon_by_2.to_cartesian(s) * 2.,
                                        o_lon.to_cartesian(s), atol=1e-10*u.kpc)
@@ -586,7 +587,7 @@ class TestSphericalOffset():
         o_lon_0 = o_lon - o_lon
         for c in o_lon_0.components:
             assert np.all(getattr(o_lon_0, c) == 0.)
-        o_lon2 = SphericalOffset(1.*u.mas/u.yr, 0.*u.mas/u.yr, 0.*u.km/u.s)
+        o_lon2 = SphericalDifferential(1*u.mas/u.yr, 0*u.mas/u.yr, 0*u.km/u.s)
         assert_quantity_allclose(o_lon2.norm(s)[0], 4.74*u.km/u.s,
                                  atol=0.01*u.km/u.s)
         assert_representation_allclose(o_lon2.to_cartesian(s) * 1000.*u.yr,
@@ -603,7 +604,7 @@ class TestSphericalOffset():
             atol=5.*u.kpc)
 
         o_lon3c = CartesianRepresentation(0., 4.74047, 0., unit=u.km/u.s)
-        o_lon3 = SphericalOffset.from_cartesian(o_lon3c, base=s)
+        o_lon3 = SphericalDifferential.from_cartesian(o_lon3c, base=s)
         assert_quantity_allclose(o_lon3.d_lon[0], 1.*u.mas/u.yr,
                                  atol=1.*u.uas/u.yr)
         s_off_big2 = s + o_lon3 * 1e5 * u.yr * u.radian/u.mas
@@ -611,26 +612,27 @@ class TestSphericalOffset():
             s_off_big2, SphericalRepresentation(90.*u.deg, 0.*u.deg,
                                                 1e5*u.kpc), atol=5.*u.kpc)
 
-    def test_offset_init_errors(self):
+    def test_differential_init_errors(self):
         s = self.s
         with pytest.raises(TypeError):
-            SphericalOffset(1.*u.arcsec, 0., 0.)
+            SphericalDifferential(1.*u.arcsec, 0., 0.)
         with pytest.raises(TypeError):
-            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc, False, False)
+            SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
+                                  False, False)
         with pytest.raises(TypeError):
-            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
+            SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
                             copy=False, d_lon=0.*u.arcsec)
         with pytest.raises(TypeError):
-            SphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
+            SphericalDifferential(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc,
                             copy=False, flying='circus')
         with pytest.raises(ValueError):
-            SphericalOffset(np.ones(2)*u.arcsec,
+            SphericalDifferential(np.ones(2)*u.arcsec,
                             np.zeros(3)*u.arcsec, np.zeros(2)*u.kpc)
         with pytest.raises(u.UnitsError):
-            SphericalOffset(1.*u.arcsec, 1.*u.s, 0.*u.kpc)
+            SphericalDifferential(1.*u.arcsec, 1.*u.s, 0.*u.kpc)
         with pytest.raises(u.UnitsError):
-            SphericalOffset(1.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
-        o = SphericalOffset(1.*u.arcsec, 1.*u.arcsec, 0.*u.km/u.s)
+            SphericalDifferential(1.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
+        o = SphericalDifferential(1.*u.arcsec, 1.*u.arcsec, 0.*u.km/u.s)
         with pytest.raises(u.UnitsError):
             o.to_cartesian(s)
         with pytest.raises(AttributeError):
@@ -638,21 +640,21 @@ class TestSphericalOffset():
         with pytest.raises(AttributeError):
             del o.d_lon
 
-        o = SphericalOffset(1.*u.arcsec, 1.*u.arcsec, 0.*u.km)
+        o = SphericalDifferential(1.*u.arcsec, 1.*u.arcsec, 0.*u.km)
         with pytest.raises(TypeError):
             o.to_cartesian()
         c = CartesianRepresentation(10., 0., 0., unit=u.km)
         with pytest.raises(TypeError):
-            SphericalOffset.to_cartesian(c)
+            SphericalDifferential.to_cartesian(c)
         with pytest.raises(TypeError):
-            SphericalOffset.from_cartesian(c)
+            SphericalDifferential.from_cartesian(c)
         with pytest.raises(TypeError):
-            SphericalOffset.from_cartesian(c, SphericalRepresentation)
+            SphericalDifferential.from_cartesian(c, SphericalRepresentation)
         with pytest.raises(TypeError):
-            SphericalOffset.from_cartesian(c, c)
+            SphericalDifferential.from_cartesian(c, c)
 
 
-class TestUnitSphericalOffset():
+class TestUnitSphericalDifferential():
     def setup(self):
         s = UnitSphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                         lat=[0., -30., 85.] * u.deg)
@@ -660,12 +662,12 @@ class TestUnitSphericalOffset():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
-    def test_simple_offsets(self):
+    def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        o_lon = UnitSphericalOffset(1.*u.arcsec, 0.*u.arcsec)
+        o_lon = UnitSphericalDifferential(1.*u.arcsec, 0.*u.arcsec)
         o_lonc = o_lon.to_cartesian(base=s)
-        o_lon2 = UnitSphericalOffset.from_cartesian(o_lonc, base=s)
+        o_lon2 = UnitSphericalDifferential.from_cartesian(o_lonc, base=s)
         assert_quantity_allclose(o_lon.d_lon, o_lon2.d_lon, atol=1.*u.narcsec)
         assert_quantity_allclose(o_lon.d_lat, o_lon2.d_lat, atol=1.*u.narcsec)
         # simple check by hand for first element.
@@ -678,7 +680,7 @@ class TestUnitSphericalOffset():
         s_lon2 = s + o_lon
         assert_representation_allclose(s_lon2, s_lon, atol=1e-10*u.one)
 
-        o_lat = UnitSphericalOffset(0.*u.arcsec, 1.*u.arcsec)
+        o_lat = UnitSphericalDifferential(0.*u.arcsec, 1.*u.arcsec)
         o_latc = o_lat.to_cartesian(base=s)
         assert_quantity_allclose(o_latc[0].xyz,
                                  [0., 0., np.pi/180./3600.]*u.one,
@@ -689,12 +691,12 @@ class TestUnitSphericalOffset():
         s_lat2 = s + o_lat
         assert_representation_allclose(s_lat2, s_lat, atol=1e-10*u.one)
 
-    def test_offset_arithmetic(self):
+    def test_differential_arithmetic(self):
         s = self.s
 
-        o_lon = UnitSphericalOffset(1.*u.arcsec, 0.*u.arcsec)
+        o_lon = UnitSphericalDifferential(1.*u.arcsec, 0.*u.arcsec)
         o_lon_by_2 = o_lon / 2.
-        assert type(o_lon_by_2) is UnitSphericalOffset
+        assert type(o_lon_by_2) is UnitSphericalDifferential
         assert_representation_allclose(o_lon_by_2.to_cartesian(s) * 2.,
                                        o_lon.to_cartesian(s), atol=1e-10*u.one)
         s_lon = s + o_lon
@@ -702,16 +704,16 @@ class TestUnitSphericalOffset():
         assert type(s_lon) is SphericalRepresentation
         assert_representation_allclose(s_lon, s_lon2, atol=1e-10*u.one)
         o_lon_rec = o_lon_by_2 + o_lon_by_2
-        assert type(o_lon_rec) is UnitSphericalOffset
+        assert type(o_lon_rec) is UnitSphericalDifferential
         assert representation_equal(o_lon, o_lon_rec)
         assert_representation_allclose(s + o_lon, s + o_lon_rec,
                                        atol=1e-10*u.one)
         o_lon_0 = o_lon - o_lon
-        assert type(o_lon_0) is UnitSphericalOffset
+        assert type(o_lon_0) is UnitSphericalDifferential
         for c in o_lon_0.components:
             assert np.all(getattr(o_lon_0, c) == 0.)
 
-        o_lon2 = UnitSphericalOffset(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+        o_lon2 = UnitSphericalDifferential(1.*u.mas/u.yr, 0.*u.mas/u.yr)
         kks = u.km/u.kpc/u.s
         assert_quantity_allclose(o_lon2.norm(s)[0], 4.74047*kks, atol=1e-4*kks)
         assert_representation_allclose(o_lon2.to_cartesian(s) * 1000.*u.yr,
@@ -729,7 +731,7 @@ class TestUnitSphericalOffset():
 
         o_lon3c = CartesianRepresentation(0., 4.74047, 0., unit=kks)
         # This looses information!!
-        o_lon3 = UnitSphericalOffset.from_cartesian(o_lon3c, base=s)
+        o_lon3 = UnitSphericalDifferential.from_cartesian(o_lon3c, base=s)
         assert_quantity_allclose(o_lon3.d_lon[0], 1.*u.mas/u.yr,
                                  atol=1.*u.uas/u.yr)
         # Part of motion kept.
@@ -742,8 +744,8 @@ class TestUnitSphericalOffset():
         assert_representation_allclose(s_off_big2[0], expected0, atol=5.*u.one)
 
 
-class TestPhysicsSphericalOffset():
-    """Test copied from SphericalOffset, so less extensive."""
+class TestPhysicsSphericalDifferential():
+    """Test copied from SphericalDifferential, so less extensive."""
     def setup(self):
         s = PhysicsSphericalRepresentation(phi=[0., 90., 315.] * u.deg,
                                            theta=[90., 120., 5.] * u.deg,
@@ -752,12 +754,12 @@ class TestPhysicsSphericalOffset():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
-    def test_simple_offsets(self):
+    def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        o_phi = PhysicsSphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_phi = PhysicsSphericalDifferential(1*u.arcsec, 0*u.arcsec, 0*u.kpc)
         o_phic = o_phi.to_cartesian(base=s)
-        o_phi2 = PhysicsSphericalOffset.from_cartesian(o_phic, base=s)
+        o_phi2 = PhysicsSphericalDifferential.from_cartesian(o_phic, base=s)
         assert_quantity_allclose(o_phi.d_phi, o_phi2.d_phi, atol=1.*u.narcsec)
         assert_quantity_allclose(o_phi.d_theta, o_phi2.d_theta,
                                  atol=1.*u.narcsec)
@@ -770,7 +772,7 @@ class TestPhysicsSphericalOffset():
         s_phi = s + 1.*u.arcsec * sf['phi'] * e['phi']
         assert_representation_allclose(o_phic, s_phi - s, atol=1e-10*u.kpc)
 
-        o_theta = PhysicsSphericalOffset(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
+        o_theta = PhysicsSphericalDifferential(0*u.arcsec, 1*u.arcsec, 0*u.kpc)
         o_thetac = o_theta.to_cartesian(base=s)
         assert_quantity_allclose(o_thetac[0].xyz,
                                  [0., 0., -np.pi/180./3600.]*u.kpc,
@@ -780,7 +782,7 @@ class TestPhysicsSphericalOffset():
         s_theta2 = s + o_theta
         assert_representation_allclose(s_theta2, s_theta, atol=1e-10*u.kpc)
 
-        o_r = PhysicsSphericalOffset(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
+        o_r = PhysicsSphericalDifferential(0*u.arcsec, 0*u.arcsec, 1*u.mpc)
         o_rc = o_r.to_cartesian(base=s)
         assert_quantity_allclose(o_rc[0].xyz, [1e-6, 0., 0.]*u.kpc,
                                  atol=1.*u.npc)
@@ -790,8 +792,8 @@ class TestPhysicsSphericalOffset():
         assert_representation_allclose(s_r2, s_r)
 
 
-class TestCylindricalOffset():
-    """Test copied from SphericalOffset, so less extensive."""
+class TestCylindricalDifferential():
+    """Test copied from SphericalDifferential, so less extensive."""
     def setup(self):
         s = CylindricalRepresentation(rho=[1, 2, 3] * u.kpc,
                                       phi=[0., 90., 315.] * u.deg,
@@ -800,10 +802,10 @@ class TestCylindricalOffset():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
-    def test_simple_offsets(self):
+    def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        o_rho = CylindricalOffset(1.*u.mpc, 0.*u.arcsec, 0.*u.kpc)
+        o_rho = CylindricalDifferential(1.*u.mpc, 0.*u.arcsec, 0.*u.kpc)
         o_rhoc = o_rho.to_cartesian(base=s)
         assert_quantity_allclose(o_rhoc[0].xyz, [1.e-6, 0., 0.]*u.kpc)
         s_rho = s + 1.*u.mpc * sf['rho'] * e['rho']
@@ -811,9 +813,9 @@ class TestCylindricalOffset():
         s_rho2 = s + o_rho
         assert_representation_allclose(s_rho2, s_rho)
 
-        o_phi = CylindricalOffset(0.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
+        o_phi = CylindricalDifferential(0.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
         o_phic = o_phi.to_cartesian(base=s)
-        o_phi2 = CylindricalOffset.from_cartesian(o_phic, base=s)
+        o_phi2 = CylindricalDifferential.from_cartesian(o_phic, base=s)
         assert_quantity_allclose(o_phi.d_rho, o_phi2.d_rho, atol=1.*u.npc)
         assert_quantity_allclose(o_phi.d_phi, o_phi2.d_phi, atol=1.*u.narcsec)
         assert_quantity_allclose(o_phi.d_z, o_phi2.d_z, atol=1.*u.npc)
@@ -824,7 +826,7 @@ class TestCylindricalOffset():
         s_phi = s + 1.*u.arcsec * sf['phi'] * e['phi']
         assert_representation_allclose(o_phic, s_phi - s, atol=1e-10*u.kpc)
 
-        o_z = CylindricalOffset(0.*u.kpc, 0.*u.arcsec, 1.*u.mpc)
+        o_z = CylindricalDifferential(0.*u.kpc, 0.*u.arcsec, 1.*u.mpc)
         o_zc = o_z.to_cartesian(base=s)
         assert_quantity_allclose(o_zc[0].xyz, [0., 0., 1.e-6]*u.kpc)
         s_z = s + 1.*u.mpc * sf['z'] * e['z']
@@ -833,8 +835,8 @@ class TestCylindricalOffset():
         assert_representation_allclose(s_z2, s_z)
 
 
-class TestCartesianOffset():
-    """Test copied from SphericalOffset, so less extensive."""
+class TestCartesianDifferential():
+    """Test copied from SphericalDifferential, so less extensive."""
     def setup(self):
         s = CartesianRepresentation(x=[1, 2, 3] * u.kpc,
                                     y=[2, 3, 1] * u.kpc,
@@ -843,24 +845,25 @@ class TestCartesianOffset():
         self.e = s.unit_vectors()
         self.sf = s.scale_factors()
 
-    def test_simple_offsets(self):
+    def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
 
-        for d, offset in (('x', CartesianOffset(1.*u.pc, 0.*u.pc, 0.*u.pc)),
-                          ('y', CartesianOffset(0.*u.pc, 1.*u.pc, 0.*u.pc)),
-                          ('z', CartesianOffset(0.*u.pc, 0.*u.pc, 1.*u.pc))):
-            o_c = offset.tocartesian(base=s)
-            o_c2 = offset.to_cartesian()
+        for d, differential in (
+                ('x', CartesianDifferential(1.*u.pc, 0.*u.pc, 0.*u.pc)),
+                ('y', CartesianDifferential(0.*u.pc, 1.*u.pc, 0.*u.pc)),
+                ('z', CartesianDifferential(0.*u.pc, 0.*u.pc, 1.*u.pc))):
+            o_c = differential.to_cartesian(base=s)
+            o_c2 = differential.to_cartesian()
             assert np.all(representation_equal(o_c, o_c2))
-            assert all(np.all(getattr(offset, 'd_'+c) == getattr(o_c, c))
+            assert all(np.all(getattr(differential, 'd_'+c) == getattr(o_c, c))
                        for c in ('x', 'y', 'z'))
             s_off = s + 1.*u.pc * sf[d] * e[d]
             assert_representation_allclose(o_c, s_off - s, atol=1e-10*u.kpc)
-            s_off2 = s + offset
+            s_off2 = s + differential
             assert_representation_allclose(s_off2, s_off)
 
 
-class TestOffsetConversion():
+class TestDifferentialConversion():
     def setup(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                     lat=[0., -30., 85.] * u.deg,
@@ -870,11 +873,11 @@ class TestOffsetConversion():
         self.sf = s.scale_factors()
 
     def test_convert_physics(self):
-        so = SphericalOffset(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
-        po = so.represent_as(PhysicsSphericalOffset)
-        so2 = SphericalOffset.from_representation(po)
+        so = SphericalDifferential(1.*u.deg, 2.*u.deg, 0.1*u.kpc)
+        po = so.represent_as(PhysicsSphericalDifferential)
+        so2 = SphericalDifferential.from_representation(po)
         assert representation_equal(so, so2)
-        po2 = PhysicsSphericalOffset.from_representation(so)
+        po2 = PhysicsSphericalDifferential.from_representation(so)
         assert representation_equal(po, po2)
         s = self.s
         p = s.represent_as(PhysicsSphericalRepresentation)
@@ -883,10 +886,10 @@ class TestOffsetConversion():
     def test_convert_unit_spherical(self):
         s = self.s
         us = s.represent_as(UnitSphericalRepresentation)
-        uo = UnitSphericalOffset(2.*u.deg, 1.*u.deg)
-        so = uo.represent_as(SphericalOffset, base=s)
+        uo = UnitSphericalDifferential(2.*u.deg, 1.*u.deg)
+        so = uo.represent_as(SphericalDifferential, base=s)
         assert_quantity_allclose(so.d_distance, 0.*u.kpc, atol=1.*u.npc)
-        uo2 = so.represent_as(UnitSphericalOffset)
+        uo2 = so.represent_as(UnitSphericalDifferential)
         assert_representation_allclose(uo.to_cartesian(us),
                                        uo2.to_cartesian(us))
 

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -8,7 +8,8 @@ from ... import units as u
 from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CylindricalRepresentation, SphericalRepresentation,
                 UnitSphericalRepresentation, SphericalOffset,
-                Longitude, Latitude)
+                CartesianOffset, UnitSphericalOffset, CylindricalOffset,
+                PhysicsSphericalOffset, Longitude, Latitude)
 from ..angle_utilities import angular_separation
 from ...utils.compat.numpy import broadcast_arrays
 from ...tests.helper import pytest, assert_quantity_allclose
@@ -523,7 +524,6 @@ class TestUnitVectorsAndScales():
 
 
 class TestSphericalOffset():
-
     def setup(self):
         s = SphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
                                     lat=[0., -30., 85.] * u.deg,
@@ -547,24 +547,27 @@ class TestSphericalOffset():
                                  [0., np.pi/180./3600., 0.]*u.kpc)
         # check all using unit vectors and scale factors.
         s_lon = s + 1.*u.arcsec * sf['lon'] * e['lon']
-        assert_representation_allclose(o_lonc, s_lon - s, atol=1e-10*u.kpc)
+        assert_representation_allclose(o_lonc, s_lon - s, atol=1*u.npc)
+        s_lon2 = s + o_lon
+        assert_representation_allclose(s_lon2, s_lon, atol=1*u.npc)
 
         o_lat = SphericalOffset(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
         o_latc = o_lat.to_cartesian(base=s)
         assert_quantity_allclose(o_latc[0].xyz,
-                                 [0., 0., np.pi/180./3600.]*u.kpc)
+                                 [0., 0., np.pi/180./3600.]*u.kpc,
+                                 atol=1.*u.npc)
         s_lat = s + 1.*u.arcsec * sf['lat'] * e['lat']
-        assert_representation_allclose(o_latc, s_lat - s, atol=1e-10*u.kpc)
+        assert_representation_allclose(o_latc, s_lat - s, atol=1*u.npc)
         s_lat2 = s + o_lat
-        assert_representation_allclose(s_lat2, s_lat, atol=1e-10*u.kpc)
+        assert_representation_allclose(s_lat2, s_lat, atol=1*u.npc)
 
         o_distance = SphericalOffset(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
         o_distancec = o_distance.to_cartesian(base=s)
         assert_quantity_allclose(o_distancec[0].xyz,
-                                 [1e-6, 0., 0.]*u.kpc)
+                                 [1e-6, 0., 0.]*u.kpc, atol=1.*u.npc)
         s_distance = s + 1.*u.mpc * sf['distance'] * e['distance']
         assert_representation_allclose(o_distancec, s_distance - s,
-                                       atol=1e-10*u.kpc)
+                                       atol=1*u.npc)
         s_distance2 = s + o_distance
         assert_representation_allclose(s_distance2, s_distance)
 
@@ -577,6 +580,12 @@ class TestSphericalOffset():
                                        o_lon.to_cartesian(s), atol=1e-10*u.kpc)
         assert_representation_allclose(s + o_lon, s + 2 * o_lon_by_2,
                                        atol=1e-10*u.kpc)
+        o_lon_rec = o_lon_by_2 + o_lon_by_2
+        assert_representation_allclose(s + o_lon, s + o_lon_rec,
+                                       atol=1e-10*u.kpc)
+        o_lon_0 = o_lon - o_lon
+        for c in o_lon_0.components:
+            assert np.all(getattr(o_lon_0, c) == 0.)
         o_lon2 = SphericalOffset(1.*u.mas/u.yr, 0.*u.mas/u.yr, 0.*u.km/u.s)
         assert_quantity_allclose(o_lon2.norm(s)[0], 4.74*u.km/u.s,
                                  atol=0.01*u.km/u.s)
@@ -641,3 +650,184 @@ class TestSphericalOffset():
             SphericalOffset.from_cartesian(c, SphericalRepresentation)
         with pytest.raises(TypeError):
             SphericalOffset.from_cartesian(c, c)
+
+
+class TestUnitSphericalOffset():
+    def setup(self):
+        s = UnitSphericalRepresentation(lon=[0., 6., 21.] * u.hourangle,
+                                        lat=[0., -30., 85.] * u.deg)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        o_lon = UnitSphericalOffset(1.*u.arcsec, 0.*u.arcsec)
+        o_lonc = o_lon.to_cartesian(base=s)
+        o_lon2 = UnitSphericalOffset.from_cartesian(o_lonc, base=s)
+        assert_quantity_allclose(o_lon.d_lon, o_lon2.d_lon, atol=1.*u.narcsec)
+        assert_quantity_allclose(o_lon.d_lat, o_lon2.d_lat, atol=1.*u.narcsec)
+        # simple check by hand for first element.
+        assert_quantity_allclose(o_lonc[0].xyz,
+                                 [0., np.pi/180./3600., 0.]*u.one)
+        # check all using unit vectors and scale factors.
+        s_lon = s + 1.*u.arcsec * sf['lon'] * e['lon']
+        assert type(s_lon) is SphericalRepresentation
+        assert_representation_allclose(o_lonc, s_lon - s, atol=1e-10*u.one)
+        s_lon2 = s + o_lon
+        assert_representation_allclose(s_lon2, s_lon, atol=1e-10*u.one)
+
+        o_lat = UnitSphericalOffset(0.*u.arcsec, 1.*u.arcsec)
+        o_latc = o_lat.to_cartesian(base=s)
+        assert_quantity_allclose(o_latc[0].xyz,
+                                 [0., 0., np.pi/180./3600.]*u.one,
+                                 atol=1e-10*u.one)
+        s_lat = s + 1.*u.arcsec * sf['lat'] * e['lat']
+        assert type(s_lat) is SphericalRepresentation
+        assert_representation_allclose(o_latc, s_lat - s, atol=1e-10*u.one)
+        s_lat2 = s + o_lat
+        assert_representation_allclose(s_lat2, s_lat, atol=1e-10*u.one)
+
+    def test_offset_arithmetic(self):
+        s = self.s
+
+        o_lon = UnitSphericalOffset(1.*u.arcsec, 0.*u.arcsec)
+        o_lon_by_2 = o_lon / 2.
+        assert type(o_lon_by_2) is UnitSphericalOffset
+        assert_representation_allclose(o_lon_by_2.to_cartesian(s) * 2.,
+                                       o_lon.to_cartesian(s), atol=1e-10*u.one)
+        s_lon = s + o_lon
+        s_lon2 = s + 2 * o_lon_by_2
+        assert type(s_lon) is SphericalRepresentation
+        assert_representation_allclose(s_lon, s_lon2, atol=1e-10*u.one)
+        o_lon_rec = o_lon_by_2 + o_lon_by_2
+        assert type(o_lon_rec) is UnitSphericalOffset
+        assert representation_equal(o_lon, o_lon_rec)
+        assert_representation_allclose(s + o_lon, s + o_lon_rec,
+                                       atol=1e-10*u.one)
+        o_lon_0 = o_lon - o_lon
+        assert type(o_lon_0) is UnitSphericalOffset
+        for c in o_lon_0.components:
+            assert np.all(getattr(o_lon_0, c) == 0.)
+
+        o_lon2 = UnitSphericalOffset(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+        kks = u.km/u.kpc/u.s
+        assert_quantity_allclose(o_lon2.norm(s)[0], 4.74047*kks, atol=1e-4*kks)
+        assert_representation_allclose(o_lon2.to_cartesian(s) * 1000.*u.yr,
+                                       o_lon.to_cartesian(s), atol=1e-10*u.one)
+        s_off = s + o_lon
+        s_off2 = s + o_lon2 * 1000.*u.yr
+        assert_representation_allclose(s_off, s_off2, atol=1e-10*u.one)
+
+        s_off_big = s + o_lon * 1e5 * u.radian/u.arcsec
+
+        assert_representation_allclose(
+            s_off_big, SphericalRepresentation(s.lon + 90.*u.deg, 0.*u.deg,
+                                               1e5*np.cos(s.lat)),
+            atol=5.*u.one)
+
+        o_lon3c = CartesianRepresentation(0., 4.74047, 0., unit=kks)
+        # This looses information!!
+        o_lon3 = UnitSphericalOffset.from_cartesian(o_lon3c, base=s)
+        assert_quantity_allclose(o_lon3.d_lon[0], 1.*u.mas/u.yr,
+                                 atol=1.*u.uas/u.yr)
+        # Part of motion kept.
+        part_kept = s.cross(CartesianRepresentation(0,1,0, unit=u.one)).norm()
+        assert_quantity_allclose(o_lon3.norm(s), 4.74047*part_kept*kks,
+                                 atol=1e-10*kks)
+        s_off_big2 = s + o_lon3 * 1e5 * u.yr * u.radian/u.mas
+        expected0 = SphericalRepresentation(90.*u.deg, 0.*u.deg,
+                                            1e5*u.one)
+        assert_representation_allclose(s_off_big2[0], expected0, atol=5.*u.one)
+
+
+class TestPhysicsSphericalOffset():
+    """Test copied from SphericalOffset, so less extensive."""
+    def setup(self):
+        s = PhysicsSphericalRepresentation(phi=[0., 90., 315.] * u.deg,
+                                           theta=[90., 120., 5.] * u.deg,
+                                           r=[1, 2, 3] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        o_phi = PhysicsSphericalOffset(1.*u.arcsec, 0.*u.arcsec, 0.*u.kpc)
+        o_phic = o_phi.to_cartesian(base=s)
+        o_phi2 = PhysicsSphericalOffset.from_cartesian(o_phic, base=s)
+        assert_quantity_allclose(o_phi.d_phi, o_phi2.d_phi, atol=1.*u.narcsec)
+        assert_quantity_allclose(o_phi.d_theta, o_phi2.d_theta,
+                                 atol=1.*u.narcsec)
+        assert_quantity_allclose(o_phi.d_r, o_phi2.d_r, atol=1.*u.npc)
+        # simple check by hand for first element.
+        assert_quantity_allclose(o_phic[0].xyz,
+                                 [0., np.pi/180./3600., 0.]*u.kpc,
+                                 atol=1.*u.npc)
+        # check all using unit vectors and scale factors.
+        s_phi = s + 1.*u.arcsec * sf['phi'] * e['phi']
+        assert_representation_allclose(o_phic, s_phi - s, atol=1e-10*u.kpc)
+
+        o_theta = PhysicsSphericalOffset(0.*u.arcsec, 1.*u.arcsec, 0.*u.kpc)
+        o_thetac = o_theta.to_cartesian(base=s)
+        assert_quantity_allclose(o_thetac[0].xyz,
+                                 [0., 0., -np.pi/180./3600.]*u.kpc,
+                                 atol=1.*u.npc)
+        s_theta = s + 1.*u.arcsec * sf['theta'] * e['theta']
+        assert_representation_allclose(o_thetac, s_theta - s, atol=1e-10*u.kpc)
+        s_theta2 = s + o_theta
+        assert_representation_allclose(s_theta2, s_theta, atol=1e-10*u.kpc)
+
+        o_r = PhysicsSphericalOffset(0.*u.arcsec, 0.*u.arcsec, 1.*u.mpc)
+        o_rc = o_r.to_cartesian(base=s)
+        assert_quantity_allclose(o_rc[0].xyz, [1e-6, 0., 0.]*u.kpc,
+                                 atol=1.*u.npc)
+        s_r = s + 1.*u.mpc * sf['r'] * e['r']
+        assert_representation_allclose(o_rc, s_r - s, atol=1e-10*u.kpc)
+        s_r2 = s + o_r
+        assert_representation_allclose(s_r2, s_r)
+
+
+class TestCylindricalOffset():
+    """Test copied from SphericalOffset, so less extensive."""
+    def setup(self):
+        s = CylindricalRepresentation(rho=[1, 2, 3] * u.kpc,
+                                      phi=[0., 90., 315.] * u.deg,
+                                      z=[3, 2, 1] * u.kpc)
+        self.s = s
+        self.e = s.unit_vectors()
+        self.sf = s.scale_factors()
+
+    def test_simple_offsets(self):
+        s, e, sf = self.s, self.e, self.sf
+
+        o_rho = CylindricalOffset(1.*u.mpc, 0.*u.arcsec, 0.*u.kpc)
+        o_rhoc = o_rho.to_cartesian(base=s)
+        assert_quantity_allclose(o_rhoc[0].xyz, [1.e-6, 0., 0.]*u.kpc)
+        s_rho = s + 1.*u.mpc * sf['rho'] * e['rho']
+        assert_representation_allclose(o_rhoc, s_rho - s, atol=1e-10*u.kpc)
+        s_rho2 = s + o_rho
+        assert_representation_allclose(s_rho2, s_rho)
+
+        o_phi = CylindricalOffset(0.*u.kpc, 1.*u.arcsec, 0.*u.kpc)
+        o_phic = o_phi.to_cartesian(base=s)
+        o_phi2 = CylindricalOffset.from_cartesian(o_phic, base=s)
+        assert_quantity_allclose(o_phi.d_rho, o_phi2.d_rho, atol=1.*u.npc)
+        assert_quantity_allclose(o_phi.d_phi, o_phi2.d_phi, atol=1.*u.narcsec)
+        assert_quantity_allclose(o_phi.d_z, o_phi2.d_z, atol=1.*u.npc)
+        # simple check by hand for first element.
+        assert_quantity_allclose(o_phic[0].xyz,
+                                 [0., np.pi/180./3600., 0.]*u.kpc)
+        # check all using unit vectors and scale factors.
+        s_phi = s + 1.*u.arcsec * sf['phi'] * e['phi']
+        assert_representation_allclose(o_phic, s_phi - s, atol=1e-10*u.kpc)
+
+        o_z = CylindricalOffset(0.*u.kpc, 0.*u.arcsec, 1.*u.mpc)
+        o_zc = o_z.to_cartesian(base=s)
+        assert_quantity_allclose(o_zc[0].xyz, [0., 0., 1.e-6]*u.kpc)
+        s_z = s + 1.*u.mpc * sf['z'] * e['z']
+        assert_representation_allclose(o_zc, s_z - s, atol=1e-10*u.kpc)
+        s_z2 = s + o_z
+        assert_representation_allclose(s_z2, s_z)

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -223,10 +223,10 @@ To see how this works, consider the following::
 
   >>> from astropy.coordinates import SphericalRepresentation, SphericalDifferential
   >>> sph_coo = SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
-                                        distance=1.*u.kpc)
+  ...                                   distance=1.*u.kpc)
   >>> sph_derivative = SphericalDifferential(d_lon=1.*u.arcsec/u.yr,
-                                             d_lat=0.*u.arcsec/u.yr,
-					     d_distance=0.*u.km/u.s)
+  ...                                        d_lat=0.*u.arcsec/u.yr,
+  ...                                        d_distance=0.*u.km/u.s)
   >>> sph_derivative.to_cartesian(base=sph_coo)
   <CartesianRepresentation (x, y, z) in arcsec kpc / (rad yr)
       ( 0.,  1.,  0.)>

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -212,18 +212,90 @@ To see how the operations work, consider the following examples::
         (  3.06161700e-16,  -5.00000000e+00,  12.),
         ( -4.00000000e+00,  -3.00000000e+00, -12.)]]>
 
+For coordinates, one also has to deal with proper motions, which describe
+velocities in spherical coordinates.  To support this, the representations
+all have corresponding ``Differential`` classes, which can holds offsets or
+derivatives in terms of the components of the representation class. Adding such
+an offset to a representation means the offset is taken in the direction of
+the corresponding coordinate.
+
+To see how this works, consider the following::
+
+  >>> from astropy.coordinates import SphericalRepresentation, SphericalDifferential
+  >>> sph_coo = SphericalRepresentation(lon=0.*u.deg, lat=0.*u.deg,
+                                        distance=1.*u.kpc)
+  >>> sph_derivative = SphericalDifferential(d_lon=1.*u.arcsec/u.yr,
+                                             d_lat=0.*u.arcsec/u.yr,
+					     d_distance=0.*u.km/u.s)
+  >>> sph_derivative.to_cartesian(base=sph_coo)
+  <CartesianRepresentation (x, y, z) in arcsec kpc / (rad yr)
+      ( 0.,  1.,  0.)>
+
+Note how the conversion to cartesian can only done using a ``base``, since
+otherwise the code cannot know what direction an increase in longitude
+corresponds to.  For ``lon=0``, this is in the ``y`` direction.  Now, to get
+the coordinates at two laters times::
+  
+  >>> sph_coo + sph_derivative * [1., 3600*180/np.pi] * u.yr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      [(  4.84813681e-06,  0.,  1.        ),
+       (  7.85398163e-01,  0.,  1.41421356)]>
+
+The above shows how addition is not to longitude itself, but in the direction
+of increasing longitude: for the large shift, by the equivalent of one radian,
+the distance has increased as well (after all, a source will likely not move
+along a curve on the sky!).  This also means that the order of operations is
+important::
+
+  >>> big_offset = SphericalDifferential(1.*u.radian, 0.*u.radian, 0.*u.kpc)
+  >>> sph_coo + big_offset + big_offset  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 1.57079633,  0.,  2.)>
+  >>> sph_coo + (big_offset + big_offset)  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 1.10714872,  0.,  2.23606798)>
+
+Often, one has just a proper motion or a radial velocity, but not both::
+
+  >>> from astropy.coordinates import UnitSphericalDifferential, RadialDifferential
+  >>> radvel = RadialDifferential(1000*u.km/u.s)
+  >>> sph_coo + radvel * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.,  0.,  2.02271217)>
+  >>> pm = UnitSphericalDifferential(1.*u.mas/u.yr, 0.*u.mas/u.yr)
+  >>> sph_coo + pm * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.0048481,  0.,  1.00001175)>
+  >>> pm + radvel
+  <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
+      ( 1.,  0.,  1000.)>
+  >>> sph_coo + (pm + radvel) * 1. * u.Myr  # doctest: +FLOAT_CMP
+  <SphericalRepresentation (lon, lat, distance) in (rad, rad, kpc)
+      ( 0.00239684,  0.,  2.02271798)>
+
+Note in the above that the proper motion is defined strictly as a change in
+longitude, i.e., it does not include a ``cos(latitude)`` term.
+
 .. _astropy-coordinates-create-repr:
 
 Creating your own representations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To create your own representation class, your class must inherit from the
-``BaseRepresentation`` class.  In addition the following must be defined:
+`~astropy.coordinates.BaseRepresentation` class.  This base has an ``__init__``
+method that will put all arguments components through their initializers,
+verify they can be broadcast against each other, and store the components on
+``self`` as the name prefixed with '_'.  Furthermore, through its metaclass it
+provides default properties for the components so that they can be accessed
+using ``<instance>.<component>``).  For the machinery to work, the following
+must be defined:
 
-* ``__init__`` method:
+* ``attr_classes`` class attribute (``OrderedDict``):
 
-  Has a signature like ``__init__(self, comp1, comp2, comp3, copy=True)``
-  for inputting the representation component values.
+  Defines through its keys the names of the components (as well as the default
+  order), and through its values the class they should be instances of (which
+  should be `~astropy.units.Quantity` or a subclass, or anything that can
+  initialize it).
 
 * ``from_cartesian`` class method:
 
@@ -234,25 +306,60 @@ To create your own representation class, your class must inherit from the
 
   Returns a `~astropy.coordinates.CartesianRepresentation` object.
 
-* ``attr_classes`` class attribute (``OrderedDict``):
+* ``__init__`` method (optional):
 
-  Defines the initializer class for each component.In most cases this
-  class should be derived from `~astropy.units.Quantity`. In particular
-  these class initializers must take the value as the first argument and
-  accept a ``unit`` keyword which takes a `~astropy.units.Unit`
-  initializer or ``None`` to indicate no unit. Also not that the keys of
-  this dictionary are treated as the names of the components for this
-  representation, with the default ordered given in the order they
-  appear as keys.
+  If you want more than the basic initialization and checks provided by the
+  base representation class, or just an explicit signature, you can define your
+  own ``__init__``. In general, it is recommended to stay close to the
+  signature assumed by the base representation, ``__init__(self, comp1, comp2,
+  comp3, copy=True)``, and use ``super`` to call the base representation
+  initializer.
 
 * ``recommended_units`` dictionary (optional):
 
-  Maps component names to the recommended unit to convert the values of
-  that component to.  Can be ``None`` (or missing) to indicate there is
-  no preferred unit.  If this dictionary is not defined, no conversion
-  of components to particular units will occur.
+  Maps component names to the recommended unit to convert the values of that
+  component to if the representation is part of a coordinate frame.  Can be
+  ``None`` (or missing) to indicate there is no preferred unit.  If this
+  dictionary is not defined, no conversion of components to particular units
+  will occur.
 
-In pseudo-code, this means that your class will look like::
+Once you do this, you will then automatically be able to call ``represent_as``
+to convert other representations to/from your representation class.  Your
+representation will also be available for use in |skycoord| and all frame
+classes.
+
+A representation class may also have a ``_unit_representation`` attribute
+(although it is not required). This attribute points to the appropriate
+"unit" representation (i.e., a representation that is dimensionless). This is
+probably only meaningful for subclasses of
+`~astropy.coordinates.SphericalRepresentation`, where it is assumed that it
+will be a subclass of `~astropy.coordinates.UnitSphericalRepresentation`.
+
+Finally, if you wish to use also offsets in your coordinate system, two further
+methods should be defined (please see, e.g.,
+`~astropy.coordinates.SphericalRepresentation` for an example):
+
+* ``unit_vectors`` method:
+
+  Returns a ``dict`` with for each component a
+  `~astropy.coordinates.CartesianRepresentation` of unit vectors in the
+  direction of each component.
+
+* ``scale_factors`` method:
+
+  Returns a ``dict`` with for each component a `~astropy.units.Quantity` with
+  the appropriate physical scale factor for a unit change in that direction.
+
+And furthermore you should define a ``Differential`` class based on
+`~astropy.coordinates.BaseDifferential`. This class can be extremly simple,
+and only needs to define:
+
+* ``base_representation`` attribute:
+
+  A link back to the representation for which this differential holds.
+
+
+In pseudo-code, this means that a class will look like::
 
     class MyRepresentation(BaseRepresentation):
 
@@ -263,7 +370,9 @@ In pseudo-code, this means that your class will look like::
         # recommended_units is optional
         recommended_units = {'comp1': u.unit1, 'comp2': u.unit2, 'comp3': u.unit3}
 
-        def __init__(self, ...):
+	# __init__ is optional
+        def __init__(self, comp1, comp2, comp3, copy=True):
+            super(MyRepresentation, self).__init__(comp1, comp2, comp3, copy=copy)
             ...
 
         @classmethod
@@ -275,14 +384,18 @@ In pseudo-code, this means that your class will look like::
             ...
             return CartesianRepresentation(...)
 
-Once you do this, you will then automatically be able to call
-``represent_as`` to convert other representations to/from your representation
-class.  Your representation will also be available for use in |skycoord|
-and all frame classes.
+	# if differential motion is needed
+	def unit_vectors(self):
+	    ...
+	    return {'comp1': CartesianRepresentation(...),
+	            'comp2': CartesianRepresentation(...),
+		    'comp3': CartesianRepresentation(...)}
 
-A representation class may also have a ``_unit_representation`` attribute
-(although it is not required). This attribute points to the appropriate
-"unit" representation (i.e., a representation that is dimensionless). This is
-probably only meaningful for subclasses of
-`~astropy.coordinates.SphericalRepresentation`, where it is assumed that it
-will be a subclass of `~astropy.coordinates.UnitSphericalRepresentation`.
+        def scale_factors(self):
+	    ...
+	    return {'comp1': ...,
+	            'comp2': ...,
+		    'comp3': ...}
+
+    class MyDifferential(BaseDifferential):
+        base_representation = MyRepresentation


### PR DESCRIPTION
I added a `.d_xyz` attribute to `CartesianDifferential`.

More controversially, I moved `get_name()` from `BaseRepresentation` to `RepresentationBase` (the superclass to all `Representation`'s and `Differential`'s). When I asked for a mapping from Rep->Dif and Dif->Rep, I think this would suffice.