### PR TITLE
Time output subformats

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -788,9 +788,9 @@ class Time(ShapedLikeNDArray):
     @precision.setter
     def precision(self, val):
         del self.cache
-        if not isinstance(val, int) or val < 0 or val > 9:
+        if not isinstance(val, int) or val < 0 or val > 19:
             raise ValueError('precision attribute must be an int between '
-                             '0 and 9')
+                             '0 and 19')
         self._time.precision = val
 
     @property

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1592,7 +1592,23 @@ class Time(ShapedLikeNDArray):
                 cache[attr] = value
             return cache[attr]
 
-        elif attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
+        elif '_' in attr:
+            fmt, _, out_subfmt = attr.rpartition('_')
+            if fmt in self.FORMATS and any(
+                    out_subfmt == subfmt[0] for subfmt in
+                    getattr(self.FORMATS[fmt], 'subfmts', ())):
+                cache = self.cache['format']
+                if attr not in cache:
+                    if fmt == self.format:
+                        tm = self
+                    else:
+                        tm = self.replicate(format=fmt)
+                    value = tm._shaped_like_input(tm._time.to_value(
+                        parent=tm, out_subfmt=out_subfmt))
+                cache[attr] = value
+                return cache[attr]
+
+        if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
             if self.scale is None:
                 raise ScaleValueError("Cannot convert TimeDelta with "
                                       "undefined scale to any defined scale.")

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -332,7 +332,71 @@ class TimeFormat(metaclass=TimeFormatMeta):
         return subfmts
 
 
-class TimeJD(TimeFormat):
+class TimeNumeric(TimeFormat):
+    subfmts = (('float64', None, np.add),
+               ('float128', None, twoval_to_float128),
+               ('O', decimal_to_twoval, twoval_to_decimal),
+               ('str', decimal_to_twoval, twoval_to_string),
+               ('bytes', bytes_to_twoval, twoval_to_bytes),
+    )
+
+    def _check_val_type(self, val1, val2):
+        """Input value validation, typically overridden by derived classes"""
+        if val1.dtype.kind == 'f':
+            val1, val2 = super()._check_val_type(val1, val2)
+        elif (val2 is not None or
+              not (val1.dtype.kind in 'US' or
+                   (val1.dtype.kind == 'O' and
+                    all(isinstance(v, Decimal) for v in val1.flat)))):
+            raise TypeError(
+                'for {} class, input should be doubles, string, or Decimal, '
+                'and second values are only allowed for doubles.'
+                .format(self.name))
+
+        for subfmt, convert, _ in self.subfmts:
+            if np.issubdtype(val1.dtype, np.dtype(subfmt)):
+                break
+        else:
+            raise ValueError('input type not among selected sub-formats.')
+
+        if convert is not None:
+            try:
+                val1, val2 = convert(val1, val2)
+            except Exception:
+                raise TypeError(
+                    'for {} class, input should be doubles, string, or Decimal, '
+                    'and second values are only allowed for doubles.'
+                    .format(self.name))
+
+        return val1, val2
+
+    def to_value(self, jd1=None, jd2=None, parent=None, out_subfmt=None):
+        """
+        Return time representation from internal jd1 and jd2.
+        Subclasses that require ``parent`` or to adjust the jds should
+        override this method.
+        """
+        # TODO: do this in metaclass.
+        if self.__class__.value.fget is not self.__class__.to_value:
+            return self.value
+
+        if jd1 is None:
+            jd1 = self.jd1
+        if jd2 is None:
+            jd2 = self.jd2
+        if out_subfmt is None:
+            out_subfmt = self.out_subfmt
+        subfmt = self._select_subfmts(out_subfmt)[0]
+        kwargs = {}
+        if subfmt[0] in ('str', 'bytes'):
+            kwargs['fmt'] = f'.{self.precision}f'
+        value = subfmt[2](jd1, jd2, **kwargs)
+        return self.mask_if_needed(value)
+
+    value = property(to_value)
+
+
+class TimeJD(TimeNumeric):
     """
     Julian Date time format.
     This represents the number of days since the beginning of
@@ -345,12 +409,8 @@ class TimeJD(TimeFormat):
         self._check_scale(self._scale)  # Validate scale.
         self.jd1, self.jd2 = day_frac(val1, val2)
 
-    @property
-    def value(self):
-        return self.jd1 + self.jd2
 
-
-class TimeMJD(TimeFormat):
+class TimeMJD(TimeNumeric):
     """
     Modified Julian Date time format.
     This represents the number of days since midnight on November 17, 1858.
@@ -358,66 +418,21 @@ class TimeMJD(TimeFormat):
     """
     name = 'mjd'
 
-    subfmts = (('float64', None, np.add),
-               ('float128', None, twoval_to_float128),
-               ('O', decimal_to_twoval, twoval_to_decimal),
-               ('str', decimal_to_twoval, twoval_to_string),
-               ('bytes', bytes_to_twoval, twoval_to_bytes),
-    )
-
-    def _check_val_type(self, val1, val2):
-        """Input value validation, typically overridden by derived classes"""
-        if val1.dtype.kind == 'f':
-            return super()._check_val_type(val1, val2)
-        elif (val2 is not None or
-              not (val1.dtype.kind in 'US' or
-                   (val1.dtype.kind == 'O' and
-                    all(isinstance(v, Decimal) for v in val1.flat)))):
-            raise TypeError(
-                'for {} class, input should be doubles, string, or Decimal, '
-                'and second values are only allowed for doubles.'
-                .format(self.name))
-
-        return val1, None
-
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
-        for subfmt, convert, _ in self.subfmts:
-            if np.issubdtype(val1.dtype, np.dtype(subfmt)):
-                break
-        else:
-            raise ValueError('input type not among selected sub-formats.')
-
-        if convert is not None:
-            val1, val2 = convert(val1, val2)
-
         jd1, jd2 = day_frac(val1, val2)
-        jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
+        jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h).
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
-    def to_value(self, parent=None, out_subfmt=None):
-        """
-        Return time representation from internal jd1 and jd2.  This is
-        the base method that ignores ``parent`` and requires that
-        subclasses implement the ``value`` property.  Subclasses that
-        require ``parent`` or have other optional args for ``to_value``
-        should compute and return the value directly.
-        """
-        if out_subfmt is None:
-            out_subfmt = self.out_subfmt
-        subfmt = self._select_subfmts(out_subfmt)[0]
+    def to_value(self, **kwargs):
         jd1 = self.jd1 - erfa.DJM0  # This cannot loose precision.
         jd2 = self.jd2
-        kwargs = {}
-        if subfmt[0] in ('str', 'bytes'):
-            kwargs['fmt'] = f'.{self.precision}f'
-        value = subfmt[2](jd1, jd2, **kwargs)
-        return self.mask_if_needed(value)
+        return super().to_value(jd1=jd1, jd2=jd2, **kwargs)
 
     value = property(to_value)
 
 
-class TimeDecimalYear(TimeFormat):
+class TimeDecimalYear(TimeNumeric):
     """
     Time as a decimal year, with integer values corresponding to midnight
     of the first day of each year.  For example 2000.5 corresponds to the
@@ -456,8 +471,7 @@ class TimeDecimalYear(TimeFormat):
 
         self.jd1, self.jd2 = day_frac(t_frac.jd1, t_frac.jd2)
 
-    @property
-    def value(self):
+    def to_value(self, **kwargs):
         scale = self.scale.upper().encode('ascii')
         iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0,  # precision=0
                                                 self.jd1, self.jd2_filled)
@@ -474,15 +488,17 @@ class TimeDecimalYear(TimeFormat):
                                           ihr, imin, isec)
         jd1_end, jd2_end = erfa.dtf2d(scale, iy_start + 1, imon, iday,
                                       ihr, imin, isec)
-
+        # Trying to be precise, but more than float64 not useful.
         dt = (self.jd1 - jd1_start) + (self.jd2 - jd2_start)
         dt_end = (jd1_end - jd1_start) + (jd2_end - jd2_start)
         decimalyear = iy_start + dt / dt_end
 
-        return decimalyear
+        return super().to_value(jd1=decimalyear, jd2=0., **kwargs)
+
+    value = property(to_value)
 
 
-class TimeFromEpoch(TimeFormat):
+class TimeFromEpoch(TimeNumeric):
     """
     Base class for times that represent the interval from a particular
     epoch as a floating point multiple of a unit time interval (e.g. seconds
@@ -540,7 +556,7 @@ class TimeFromEpoch(TimeFormat):
 
         self.jd1, self.jd2 = day_frac(tm._time.jd1, tm._time.jd2)
 
-    def to_value(self, parent=None):
+    def to_value(self, parent=None, **kwargs):
         # Make sure that scale is the same as epoch scale so we can just
         # subtract the epoch and convert
         if self.scale != self.epoch_scale:
@@ -558,10 +574,10 @@ class TimeFromEpoch(TimeFormat):
         else:
             jd1, jd2 = self.jd1, self.jd2
 
-        time_from_epoch = ((jd1 - self.epoch.jd1) +
-                           (jd2 - self.epoch.jd2)) / self.unit
+        time_from_epoch1, time_from_epoch2 = day_frac(
+            jd1 - self.epoch.jd1, jd2 - self.epoch.jd2, divisor=self.unit)
 
-        return self.mask_if_needed(time_from_epoch)
+        return super().to_value(jd1=time_from_epoch1, jd2=time_from_epoch2, **kwargs)
 
     value = property(to_value)
 
@@ -1341,7 +1357,7 @@ class TimeFITS(TimeString):
         return super().value
 
 
-class TimeEpochDate(TimeFormat):
+class TimeEpochDate(TimeNumeric):
     """
     Base class for support floating point Besselian and Julian epoch dates
     """
@@ -1353,10 +1369,12 @@ class TimeEpochDate(TimeFormat):
         jd1, jd2 = epoch_to_jd(val1 + val2)
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
-    @property
-    def value(self):
+    def to_value(self, **kwargs):
         jd_to_epoch = getattr(erfa, self.jd_to_epoch)
-        return jd_to_epoch(self.jd1, self.jd2)
+        value = jd_to_epoch(self.jd1, self.jd2)
+        return super().to_value(jd1=value, jd2=0., **kwargs)
+
+    value = property(to_value)
 
 
 class TimeBesselianEpoch(TimeEpochDate):
@@ -1466,6 +1484,10 @@ class TimeDeltaFormat(TimeFormat, metaclass=TimeDeltaFormatMeta):
     @property
     def value(self):
         return (self.jd1 + self.jd2) / self.unit
+
+
+class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
+    pass
 
 
 class TimeDeltaSec(TimeDeltaFormat):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -6,6 +6,7 @@ import time
 import re
 import datetime
 import warnings
+from decimal import Decimal
 from collections import OrderedDict, defaultdict
 
 import numpy as np
@@ -54,21 +55,62 @@ def _regexify_subfmts(subfmts):
     new_subfmts = []
     for subfmt_tuple in subfmts:
         subfmt_in = subfmt_tuple[1]
-        for strptime_code, regex in (('%Y', r'(?P<year>\d\d\d\d)'),
-                                     ('%m', r'(?P<mon>\d{1,2})'),
-                                     ('%d', r'(?P<mday>\d{1,2})'),
-                                     ('%H', r'(?P<hour>\d{1,2})'),
-                                     ('%M', r'(?P<min>\d{1,2})'),
-                                     ('%S', r'(?P<sec>\d{1,2})')):
-            subfmt_in = subfmt_in.replace(strptime_code, regex)
+        if isinstance(subfmt_in, str):
+            for strptime_code, regex in (('%Y', r'(?P<year>\d\d\d\d)'),
+                                         ('%m', r'(?P<mon>\d{1,2})'),
+                                         ('%d', r'(?P<mday>\d{1,2})'),
+                                         ('%H', r'(?P<hour>\d{1,2})'),
+                                         ('%M', r'(?P<min>\d{1,2})'),
+                                         ('%S', r'(?P<sec>\d{1,2})')):
+                subfmt_in = subfmt_in.replace(strptime_code, regex)
 
-        if '%' not in subfmt_in:
-            subfmt_tuple = (subfmt_tuple[0],
-                            re.compile(subfmt_in + '$'),
-                            subfmt_tuple[2])
+            if '%' not in subfmt_in:
+                subfmt_tuple = (subfmt_tuple[0],
+                                re.compile(subfmt_in + '$'),
+                                subfmt_tuple[2])
         new_subfmts.append(subfmt_tuple)
 
     return tuple(new_subfmts)
+
+
+def decimal_to_twoval1(val1, val2=None):
+    i, f = divmod(Decimal(val1), 1)
+    return float(i), float(f)
+
+
+decimal_to_twoval = np.vectorize(decimal_to_twoval1)
+
+
+def bytes_to_twoval1(val1, val2=None):
+    return decimal_to_twoval1(val1.decode('ascii'))
+
+
+bytes_to_twoval = np.vectorize(bytes_to_twoval1)
+
+
+def twoval_to_float128(val1, val2):
+    return val1.astype(np.float128) + val2.astype(np.float128)
+
+
+def twoval_to_decimal1(val1, val2):
+    return Decimal(val1) + Decimal(val2)
+
+
+twoval_to_decimal = np.vectorize(twoval_to_decimal1)
+
+
+def twoval_to_string1(val1, val2, fmt):
+    return format(twoval_to_decimal1(val1, val2), fmt)
+
+
+twoval_to_string = np.vectorize(twoval_to_string1, excluded='fmt')
+
+
+def twoval_to_bytes1(val1, val2, fmt):
+    return format(twoval_to_decimal1(val1, val2), fmt).encode('ascii')
+
+
+twoval_to_bytes = np.vectorize(twoval_to_bytes1, excluded='fmt')
 
 
 class TimeFormatMeta(type):
@@ -277,6 +319,18 @@ class TimeFormat(metaclass=TimeFormatMeta):
     def value(self):
         raise NotImplementedError
 
+    def _select_subfmts(self, pattern):
+        """
+        Return a list of subformats where name matches ``pattern`` using
+        fnmatch.
+        """
+
+        fnmatchcase = fnmatch.fnmatchcase
+        subfmts = [x for x in self.subfmts if fnmatchcase(x[0], pattern)]
+        if len(subfmts) == 0:
+            raise ValueError(f'No subformats match {pattern}')
+        return subfmts
+
 
 class TimeJD(TimeFormat):
     """
@@ -304,19 +358,55 @@ class TimeMJD(TimeFormat):
     """
     name = 'mjd'
 
+    subfmts = (('float64', None, np.add),
+               ('float128', None, twoval_to_float128),
+               ('O', decimal_to_twoval, twoval_to_decimal),
+               ('U', decimal_to_twoval, twoval_to_string),
+               ('S', bytes_to_twoval, twoval_to_bytes),
+    )
+
+    def _check_val_type(self, val1, val2):
+        """Input value validation, typically overridden by derived classes"""
+        if val1.dtype.kind == 'f':
+            return super()._check_val_type(val1, val2)
+        elif (val2 is not None or
+              not (val1.dtype.kind in 'US' or
+                   (val1.dtype.kind == 'O' and
+                    all(isinstance(v, Decimal) for v in val1.flat)))):
+            raise TypeError(
+                'for {} class, input should be doubles, string, or Decimal, '
+                'and second values are only allowed for doubles.'
+                .format(self.name))
+
+        return val1, None
+
     def set_jds(self, val1, val2):
-        # TODO - this routine and vals should be Cythonized to follow the ERFA
-        # convention of preserving precision by adding to the larger of the two
-        # values in a vectorized operation.  But in most practical cases the
-        # first one is probably biggest.
         self._check_scale(self._scale)  # Validate scale.
+        for subfmt, convert, _ in self.subfmts:
+            if np.issubdtype(val1.dtype, np.dtype(subfmt)):
+                break
+        else:
+            raise ValueError('input type not among selected sub-formats.')
+
+        if fnmatch.fnmatchcase(subfmt, self.out_subfmt):
+            self.out_subfmt = subfmt
+
+        if convert is not None:
+            val1, val2 = convert(val1, val2)
+
         jd1, jd2 = day_frac(val1, val2)
         jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     @property
     def value(self):
-        return (self.jd1 - erfa.DJM0) + self.jd2
+        jd1 = self.jd1 - erfa.DJM0  # This cannot loose precision.
+        jd2 = self.jd2
+        subfmt = self._select_subfmts(self.out_subfmt)[0]
+        kwargs = {}
+        if subfmt[0] in 'SU':
+            kwargs['fmt'] = f'.{self.precision}f'
+        return subfmt[2](jd1, jd2, **kwargs)
 
 
 class TimeDecimalYear(TimeFormat):
@@ -1022,18 +1112,6 @@ class TimeString(TimeUnique):
             outs.append(str(self.format_string(str_fmt, **kwargs)))
 
         return np.array(outs).reshape(self.jd1.shape)
-
-    def _select_subfmts(self, pattern):
-        """
-        Return a list of subformats where name matches ``pattern`` using
-        fnmatch.
-        """
-
-        fnmatchcase = fnmatch.fnmatchcase
-        subfmts = [x for x in self.subfmts if fnmatchcase(x[0], pattern)]
-        if len(subfmts) == 0:
-            raise ValueError(f'No subformats match {pattern}')
-        return subfmts
 
 
 class TimeISO(TimeString):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -388,9 +388,6 @@ class TimeMJD(TimeFormat):
         else:
             raise ValueError('input type not among selected sub-formats.')
 
-        if fnmatch.fnmatchcase(subfmt, self.out_subfmt):
-            self.out_subfmt = subfmt
-
         if convert is not None:
             val1, val2 = convert(val1, val2)
 
@@ -398,15 +395,26 @@ class TimeMJD(TimeFormat):
         jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
-    @property
-    def value(self):
+    def to_value(self, parent=None, out_subfmt=None):
+        """
+        Return time representation from internal jd1 and jd2.  This is
+        the base method that ignores ``parent`` and requires that
+        subclasses implement the ``value`` property.  Subclasses that
+        require ``parent`` or have other optional args for ``to_value``
+        should compute and return the value directly.
+        """
+        if out_subfmt is None:
+            out_subfmt = self.out_subfmt
+        subfmt = self._select_subfmts(out_subfmt)[0]
         jd1 = self.jd1 - erfa.DJM0  # This cannot loose precision.
         jd2 = self.jd2
-        subfmt = self._select_subfmts(self.out_subfmt)[0]
         kwargs = {}
         if subfmt[0] in ('str', 'bytes'):
             kwargs['fmt'] = f'.{self.precision}f'
-        return subfmt[2](jd1, jd2, **kwargs)
+        value = subfmt[2](jd1, jd2, **kwargs)
+        return self.mask_if_needed(value)
+
+    value = property(to_value)
 
 
 class TimeDecimalYear(TimeFormat):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -361,8 +361,8 @@ class TimeMJD(TimeFormat):
     subfmts = (('float64', None, np.add),
                ('float128', None, twoval_to_float128),
                ('O', decimal_to_twoval, twoval_to_decimal),
-               ('U', decimal_to_twoval, twoval_to_string),
-               ('S', bytes_to_twoval, twoval_to_bytes),
+               ('str', decimal_to_twoval, twoval_to_string),
+               ('bytes', bytes_to_twoval, twoval_to_bytes),
     )
 
     def _check_val_type(self, val1, val2):
@@ -404,7 +404,7 @@ class TimeMJD(TimeFormat):
         jd2 = self.jd2
         subfmt = self._select_subfmts(self.out_subfmt)[0]
         kwargs = {}
-        if subfmt[0] in 'SU':
+        if subfmt[0] in ('str', 'bytes'):
             kwargs['fmt'] = f'.{self.precision}f'
         return subfmt[2](jd1, jd2, **kwargs)
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,6 +5,7 @@ import copy
 import functools
 import datetime
 from copy import deepcopy
+from decimal import Decimal
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -820,6 +821,45 @@ class TestSubFormat:
         # Values from issue #1118
         t = Time('2004-09-16T23:59:59', scale='utc')
         assert allclose_sec(t.unix, 1095379199.0)
+
+
+class TestNumericalSubFormat:
+    def test_explicit_example(self):
+        t = Time('54321.000000000001', format='mjd', precision=13)
+        assert t == Time(54321, 1e-12, format='mjd')
+        assert t.mjd == 54321.  # Lost precision!
+        assert t.mjd_str == '54321.0000000000010'
+        assert t.mjd_bytes == b'54321.0000000000010'
+        assert t.value == 54321.  # Lost precision!
+        t.out_subfmt = 'str'
+        assert t.value == '54321.0000000000010'
+        assert t.mjd == '54321.0000000000010'
+
+    def test_subformat_input(self):
+        s = '54321.01234567890123456789'
+        i, f = s.split('.')  # Note, OK only for fraction < 0.5
+        t = Time(float(i), float('.'+f), format='mjd')
+        t_str = Time(s, format='mjd')
+        t_bytes = Time(s.encode('ascii'), format='mjd')
+        t_decimal = Time(Decimal(s), format='mjd')
+        assert t_str == t
+        assert t_bytes == t
+        assert t_decimal == t
+
+    @pytest.mark.parametrize('out_subfmt', ('str', 'bytes'))
+    def test_subformat_output(self, out_subfmt):
+        i = 54321
+        f = np.array([0., 1e-9, 1e-12])
+        t = Time(i, f, format='mjd', out_subfmt=out_subfmt, precision=13)
+        t_value = t.value
+        expected = np.array([f'{i}.' + f'{_f:14.13f}'.split('.')[1]
+                             for _f in f], dtype=out_subfmt)
+        assert np.all(t_value == expected)
+
+        # Explicit value.
+        t = Time(i, f, format='mjd', precision=13)
+        t_mjd_subfmt = getattr(t, f'mjd_{out_subfmt}')
+        assert np.all(t_mjd_subfmt == expected)
 
 
 class TestSofaErrors:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -861,6 +861,30 @@ class TestNumericalSubFormat:
         t_mjd_subfmt = getattr(t, f'mjd_{out_subfmt}')
         assert np.all(t_mjd_subfmt == expected)
 
+    def test_explicit_other_formats(self):
+        t = Time('2451544.5333981', format='jd', scale='tai', precision=8)
+        assert t == Time(2451544.5, .0333981, format='jd', scale='tai')
+        assert t.jd_str == '2451544.53339810'
+        t = Time('2000.54321', format='decimalyear', precision=6)
+        assert t == Time(2000., 0.54321, format='decimalyear')
+        assert t.decimalyear_str == '2000.543210'
+        t = Time('100.0123456', format='cxcsec', precision=6)
+        assert t == Time(100.0123456, format='cxcsec')
+        assert t.cxcsec_str == '100.012346'
+        t = Time('100.0123456', format='unix', precision=7)
+        assert t == Time(100.0123456, format='unix')
+        assert t.unix_str == '100.0123456'
+        t = Time('100.0123456', format='gps')
+        assert t == Time(100.0123456, format='gps')
+        assert t.gps_str == '100.012'
+        # Note: cannot fully test _str format since byear_str exists.
+        t = Time('1950.1', format='byear', scale='tai', out_subfmt='str')
+        assert t == Time(1950.1, format='byear', scale='tai')
+        assert t.value == '1950.100'
+        t = Time('2000.1', format='jyear', scale='tai', out_subfmt='str')
+        assert t == Time(2000.1, format='jyear', scale='tai')
+        assert t.value == '2000.100'
+
 
 class TestSofaErrors:
     """Test that erfa status return values are handled correctly"""


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

I went ahead and fixed some of my more annoying comments. There's still a problem of how to handle TimeDelta objects - the subformats are found as attributes but don't generate the right types.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
