### PR TITLE
Time output subformats

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1605,7 +1605,7 @@ class Time(ShapedLikeNDArray):
                         tm = self.replicate(format=fmt)
                     value = tm._shaped_like_input(tm._time.to_value(
                         parent=tm, out_subfmt=out_subfmt))
-                cache[attr] = value
+                    cache[attr] = value
                 return cache[attr]
 
         if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -6,7 +6,7 @@ import time
 import re
 import datetime
 import warnings
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from collections import OrderedDict, defaultdict
 
 import numpy as np
@@ -26,7 +26,8 @@ __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
            'TimeDeltaFormat', 'TimeDeltaSec', 'TimeDeltaJD',
            'TimeEpochDateString', 'TimeBesselianEpochString',
            'TimeJulianEpochString', 'TIME_FORMATS', 'TIME_DELTA_FORMATS',
-           'TimezoneInfo', 'TimeDeltaDatetime', 'TimeDatetime64', 'TimeYMDHMS']
+           'TimezoneInfo', 'TimeDeltaDatetime', 'TimeDatetime64', 'TimeYMDHMS',
+           'TimeNumeric', 'TimeDeltaNumeric']
 
 __doctest_skip__ = ['TimePlotDate']
 
@@ -40,6 +41,8 @@ TIME_DELTA_FORMATS = OrderedDict()
 # Rots et al. 2015, A&A 574:A36, and timescales used here.
 FITS_DEPRECATED_SCALES = {'TDT': 'tt', 'ET': 'tt',
                           'GMT': 'utc', 'UT': 'utc', 'IAT': 'tai'}
+
+_enough_decimal_places = 34  # to represent two doubles
 
 
 def _regexify_subfmts(subfmts):
@@ -74,7 +77,9 @@ def _regexify_subfmts(subfmts):
 
 
 def decimal_to_twoval1(val1, val2=None):
-    i, f = divmod(Decimal(val1), 1)
+    with localcontext() as ctx:
+        ctx.prec = _enough_decimal_places
+        i, f = divmod(Decimal(val1), 1)
     return float(i), float(f)
 
 
@@ -88,12 +93,14 @@ def bytes_to_twoval1(val1, val2=None):
 bytes_to_twoval = np.vectorize(bytes_to_twoval1)
 
 
-def twoval_to_float128(val1, val2):
-    return val1.astype(np.float128) + val2.astype(np.float128)
+def twoval_to_longdouble(val1, val2):
+    return val1.astype(np.longdouble) + val2.astype(np.longdouble)
 
 
 def twoval_to_decimal1(val1, val2):
-    return Decimal(val1) + Decimal(val2)
+    with localcontext() as ctx:
+        ctx.prec = _enough_decimal_places
+        return Decimal(val1) + Decimal(val2)
 
 
 twoval_to_decimal = np.vectorize(twoval_to_decimal1)
@@ -333,11 +340,12 @@ class TimeFormat(metaclass=TimeFormatMeta):
 
 
 class TimeNumeric(TimeFormat):
-    subfmts = (('float64', None, np.add),
-               ('float128', None, twoval_to_float128),
-               ('O', decimal_to_twoval, twoval_to_decimal),
-               ('str', decimal_to_twoval, twoval_to_string),
-               ('bytes', bytes_to_twoval, twoval_to_bytes),
+    subfmts = (
+        ('float', np.float64, None, np.add),
+        ('long', np.longdouble, None, twoval_to_longdouble),
+        ('decimal', np.dtype(object), decimal_to_twoval, twoval_to_decimal),
+        ('str', np.str_, decimal_to_twoval, twoval_to_string),
+        ('bytes', np.bytes_, bytes_to_twoval, twoval_to_bytes),
     )
 
     def _check_val_type(self, val1, val2):
@@ -353,8 +361,8 @@ class TimeNumeric(TimeFormat):
                 'and second values are only allowed for doubles.'
                 .format(self.name))
 
-        for subfmt, convert, _ in self.subfmts:
-            if np.issubdtype(val1.dtype, np.dtype(subfmt)):
+        for subfmt, dtype, convert, _ in self.subfmts:
+            if np.issubdtype(val1.dtype, dtype):
                 break
         else:
             raise ValueError('input type not among selected sub-formats.')
@@ -390,7 +398,7 @@ class TimeNumeric(TimeFormat):
         kwargs = {}
         if subfmt[0] in ('str', 'bytes'):
             kwargs['fmt'] = f'.{self.precision}f'
-        value = subfmt[2](jd1, jd2, **kwargs)
+        value = subfmt[3](jd1, jd2, **kwargs)
         return self.mask_if_needed(value)
 
     value = property(to_value)
@@ -1490,13 +1498,13 @@ class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
     pass
 
 
-class TimeDeltaSec(TimeDeltaFormat):
+class TimeDeltaSec(TimeDeltaNumeric):
     """Time delta in SI seconds"""
     name = 'sec'
     unit = 1. / erfa.DAYSEC  # for quantity input
 
 
-class TimeDeltaJD(TimeDeltaFormat):
+class TimeDeltaJD(TimeDeltaNumeric):
     """Time delta in Julian days (86400 SI seconds)"""
     name = 'jd'
     unit = 1.

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,7 +5,7 @@ import copy
 import functools
 import datetime
 from copy import deepcopy
-from decimal import Decimal
+from decimal import Decimal, localcontext
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -884,6 +884,47 @@ class TestNumericalSubFormat:
         t = Time('2000.1', format='jyear', scale='tai', out_subfmt='str')
         assert t == Time(2000.1, format='jyear', scale='tai')
         assert t.value == '2000.100'
+
+    def test_basic_subformat_usage(self):
+        Time('2001', format='jyear', scale='tai').jyear_str
+
+    def test_basic_subformat_setting(self):
+        t = Time('2001', format='jyear', scale='tai')
+        t.format = "mjd"
+        t.mjd_str
+
+    def test_basic_subformat_cache(self):
+        t = Time('2001', format='jyear', scale='tai')
+        t.jyear_str
+        t.jyear_str
+
+    @pytest.mark.parametrize("fmt", ["jd", "mjd", "cxcsec", "unix", "gps", "jyear"])
+    def test_decimal_context_does_not_affect_string(self, fmt):
+        t = Time('2001', format='jyear', scale='tai')
+        t.format = fmt
+        with localcontext() as ctx:
+            ctx.prec = 2
+            t_s_2 = getattr(t, fmt+"_str")
+        t2 = Time('2001', format='jyear', scale='tai')
+        t2.format = fmt
+        with localcontext() as ctx:
+            ctx.prec = 40
+            t2_s_40 = getattr(t2, fmt+"_str")
+        assert t_s_2 == t2_s_40
+
+    # TODO(aarchiba): check cache responds appropriately to Decimal context
+    def test_decimal_context_caching(self):
+        t = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
+        with localcontext() as ctx:
+            ctx.prec = 2
+            t_s_2 = t.mjd_O
+        t2 = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
+        with localcontext() as ctx:
+            ctx.prec = 40
+            t_s_40 = t.mjd_O
+            t2_s_40 = t2.mjd_O
+        assert t_s_2 != t_s_40
+        assert t_s_40 == t2_s_40
 
 
 class TestSofaErrors:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -886,14 +886,14 @@ class TestNumericalSubFormat:
         assert t.value == '2000.100'
 
     def test_basic_subformat_usage(self):
-        Time('2001', format='jyear', scale='tai').jyear_str
+        assert isinstance(Time('2001', format='jyear', scale='tai').jyear_str, str)
 
     def test_basic_subformat_setting(self):
         t = Time('2001', format='jyear', scale='tai')
         t.format = "mjd"
-        t.mjd_str
+        assert t.mjd_str.startswith("5")
 
-    def test_basic_subformat_cache(self):
+    def test_basic_subformat_cache_does_not_crash(self):
         t = Time('2001', format='jyear', scale='tai')
         t.jyear_str
         t.jyear_str
@@ -910,21 +910,33 @@ class TestNumericalSubFormat:
         with localcontext() as ctx:
             ctx.prec = 40
             t2_s_40 = getattr(t2, fmt+"_str")
-        assert t_s_2 == t2_s_40
+        assert t_s_2 == t2_s_40, "String representation should not depend on Decimal context"
 
-    # TODO(aarchiba): check cache responds appropriately to Decimal context
     def test_decimal_context_caching(self):
         t = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
         with localcontext() as ctx:
             ctx.prec = 2
-            t_s_2 = t.mjd_O
+            t_s_2 = t.mjd_decimal
         t2 = Time(val=58000, val2=1e-14, format='mjd', scale='tai')
         with localcontext() as ctx:
             ctx.prec = 40
-            t_s_40 = t.mjd_O
-            t2_s_40 = t2.mjd_O
-        assert t_s_2 != t_s_40
-        assert t_s_40 == t2_s_40
+            t_s_40 = t.mjd_decimal
+            t2_s_40 = t2.mjd_decimal
+        assert t_s_2 == t_s_40, "Should be the same but cache might make this automatic"
+        assert t_s_2 == t2_s_40, "Different precision should produce the same results"
+
+    @pytest.mark.parametrize("f, s, t", [("sec", "long", np.longdouble),
+                                      ("sec", "decimal", Decimal),
+                                      ("sec", "str", str)])
+    def test_timedelta_basic(self, f, s, t):
+        dt = (Time("58000", format="mjd", scale="tai")
+              - Time("58001", format="mjd", scale="tai"))
+
+        assert isinstance(getattr(dt, "_".join((f,s))), t)
+        dt.format = f
+        dt.out_subfmt = s
+        assert isinstance(dt.value, t)
+        assert isinstance(dt.to_value(), t)
 
 
 class TestSofaErrors:


### PR DESCRIPTION

I went ahead and fixed some of my more annoying comments on https://github.com/astropy/astropy/pull/9361 . There's still a problem of how to handle TimeDelta objects - the subformats are found as attributes but don't generate the right types.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->