### PR TITLE
Revert show_dtype=None back to show_dtype=False

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -219,7 +219,7 @@ class TableFormatter:
         return max_lines, max_width
 
     def _pformat_col(self, col, max_lines=None, show_name=True, show_unit=None,
-                     show_dtype=None, show_length=None, html=False, align=None):
+                     show_dtype=False, show_length=None, html=False, align=None):
         """Return a list of formatted string representation of column values.
 
         Parameters
@@ -236,8 +236,7 @@ class TableFormatter:
             for the unit.
 
         show_dtype : bool
-            Include column dtype. Default is to show it only if the
-            column is multidimensional.
+            Include column dtype. Default is False.
 
         show_length : bool
             Include column length at end.  Default is to show this only
@@ -263,8 +262,6 @@ class TableFormatter:
         """
         if show_unit is None:
             show_unit = col.info.unit is not None
-        if show_dtype is None:
-            show_dtype = bool(getattr(col, 'shape', ())[1:])
 
         outs = {}  # Some values from _pformat_col_iter iterator that are needed here
         col_strs_iter = self._pformat_col_iter(col, max_lines, show_name=show_name,
@@ -361,7 +358,7 @@ class TableFormatter:
         return f"{name}{sep}[{structure}]"
 
     def _pformat_col_iter(self, col, max_lines, show_name, show_unit, outs,
-                          show_dtype=None, show_length=None):
+                          show_dtype=False, show_length=None):
         """Iterator which yields formatted string representation of column values.
 
         Parameters
@@ -382,8 +379,7 @@ class TableFormatter:
             defined within the iterator.
 
         show_dtype : bool
-            Include column dtype. Default is to show the dtype only if
-            the column is multidimensional.
+            Include column dtype. Default is False.
 
         show_length : bool
             Include column length at end.  Default is to show this only
@@ -506,7 +502,7 @@ class TableFormatter:
         outs['i_dashes'] = i_dashes
 
     def _pformat_table(self, table, max_lines=None, max_width=None,
-                       show_name=True, show_unit=None, show_dtype=None,
+                       show_name=True, show_unit=None, show_dtype=False,
                        html=False, tableid=None, tableclass=None, align=None):
         """Return a list of lines for the formatted string representation of
         the table.
@@ -528,8 +524,7 @@ class TableFormatter:
             for the unit.
 
         show_dtype : bool
-            Include a header row for column dtypes. Default is to show
-            a row for dtype only if one or more columns is multidimensional.
+            Include a header row for column dtypes. Default is to False.
 
         html : bool
             Format the output as an HTML table. Default is False.
@@ -565,10 +560,6 @@ class TableFormatter:
 
         if show_unit is None:
             show_unit = any(col.info.unit for col in table.columns.values())
-
-        if show_dtype is None:
-            show_dtype = any(getattr(col, 'shape', [])[1:]
-                             for col in table.columns.values())
 
         # Coerce align into a correctly-sized list of alignments (if possible)
         n_cols = len(table.columns)
@@ -661,7 +652,7 @@ class TableFormatter:
         return rows, outs
 
     def _more_tabcol(self, tabcol, max_lines=None, max_width=None,
-                     show_name=True, show_unit=None, show_dtype=None):
+                     show_name=True, show_unit=None, show_dtype=False):
         """Interactive "more" of a table or column.
 
         Parameters
@@ -681,8 +672,7 @@ class TableFormatter:
             for the unit.
 
         show_dtype : bool
-            Include a header row for column dtypes. Default is to show
-            the header only if the column is multidimensional.
+            Include a header row for column dtypes. Default is False.
         """
         allowed_keys = 'f br<>qhpn'
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -94,8 +94,7 @@ _pprint_docs = """
         for the unit.
 
     show_dtype : bool
-        Include a header row for column dtypes. Default is to show
-        a row for dtype only if one or more columns is multidimensional.
+        Include a header row for column dtypes. Default is False.
 
     align : str or list or tuple or None
         Left/right alignment of columns. Default is right (None) for all
@@ -1542,7 +1541,7 @@ class Table:
         return self._base_repr_(html=False, max_width=None)
 
     def __str__(self):
-        return '\n'.join(self.pformat(show_dtype=False))
+        return '\n'.join(self.pformat())
 
     def __bytes__(self):
         return str(self).encode('utf-8')
@@ -1592,7 +1591,7 @@ class Table:
 
     @format_doc(_pprint_docs)
     def pprint(self, max_lines=None, max_width=None, show_name=True,
-               show_unit=None, show_dtype=None, align=None):
+               show_unit=None, show_dtype=False, align=None):
         """Print a formatted string representation of the table.
 
         If no value of ``max_lines`` is supplied then the height of the
@@ -1622,7 +1621,7 @@ class Table:
 
     @format_doc(_pprint_docs)
     def pprint_all(self, max_lines=-1, max_width=-1, show_name=True,
-                   show_unit=None, show_dtype=None, align=None):
+                   show_unit=None, show_dtype=False, align=None):
         """Print a formatted string representation of the entire table.
 
         This method is the same as `astropy.table.Table.pprint` except that
@@ -1697,7 +1696,7 @@ class Table:
         if table_class == 'astropy-default':
             table_class = conf.default_notebook_table_class
         html = display_table._base_repr_(html=True, max_width=-1, tableid=tableid,
-                                         max_lines=-1, show_dtype=None,
+                                         max_lines=-1, show_dtype=False,
                                          tableclass=table_class)
 
         columns = display_table.columns.values()
@@ -1787,7 +1786,7 @@ class Table:
 
     @format_doc(_pformat_docs, id="{id}")
     def pformat(self, max_lines=None, max_width=None, show_name=True,
-                show_unit=None, show_dtype=None, html=False, tableid=None,
+                show_unit=None, show_dtype=False, html=False, tableid=None,
                 align=None, tableclass=None):
         """Return a list of lines for the formatted string representation of
         the table.
@@ -1816,7 +1815,7 @@ class Table:
 
     @format_doc(_pformat_docs, id="{id}")
     def pformat_all(self, max_lines=-1, max_width=-1, show_name=True,
-                    show_unit=None, show_dtype=None, html=False, tableid=None,
+                    show_unit=None, show_dtype=False, html=False, tableid=None,
                     align=None, tableclass=None):
         """Return a list of lines for the formatted string representation of
         the entire table.
@@ -1838,7 +1837,7 @@ class Table:
                             align, tableclass)
 
     def more(self, max_lines=None, max_width=None, show_name=True,
-             show_unit=None, show_dtype=True):
+             show_unit=None, show_dtype=False):
         """Interactively browse table with a paging interface.
 
         Supported keys::
@@ -1870,7 +1869,7 @@ class Table:
             for the unit.
 
         show_dtype : bool
-            Include a header row for column dtypes. Default is True.
+            Include a header row for column dtypes. Default is False.
         """
         self.formatter._more_tabcol(self, max_lines, max_width, show_name=show_name,
                                     show_unit=show_unit, show_dtype=show_dtype)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -749,7 +749,7 @@ def test_ndarray_mixin():
     assert t[1]['d'][0] == d[1][0]
     assert t[1]['d'][1] == d[1][1]
 
-    assert t.pformat() == [
+    assert t.pformat(show_dtype=True) == [
         '  a [f0, f1]     b [x, y]      c [rx, ry]      d    ',
         '(int32, str1) (int32, str2) (float64, str3) int64[2]',
         '------------- ------------- --------------- --------',

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -720,7 +720,7 @@ class TestJoin():
                '     3 0.0 .. 0.0    -- .. --',
                '     4 1.1 .. 1.0    -- .. --',
                '     5   -- .. --  0.5 .. 0.0']
-        assert str(t12).splitlines() == exp
+        assert t12.pformat(show_dtype=True) == exp
 
     def test_keys_left_right_basic(self):
         """Test using the keys_left and keys_right args to specify different

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -29,14 +29,14 @@ class TestMultiD():
                np.array([[5, 6],
                          [50, 60]], dtype=np.int64)]
         t = table_type(arr)
-        lines = t.pformat()
+        lines = t.pformat(show_dtype=True)
         assert lines == ['  col0     col1     col2  ',
                          'int64[2] int64[2] int64[2]',
                          '-------- -------- --------',
                          '  1 .. 2   3 .. 4   5 .. 6',
                          '10 .. 20 30 .. 40 50 .. 60']
 
-        lines = t.pformat(html=True)
+        lines = t.pformat(html=True, show_dtype=True)
         assert lines == [
             f'<table id="table{id(t)}">',
             '<thead><tr><th>col0</th><th>col1</th><th>col2</th></tr></thead>',
@@ -56,7 +56,7 @@ class TestMultiD():
             '</table></div>']
 
         t = table_type([arr])
-        lines = t.pformat()
+        lines = t.pformat(show_dtype=True)
         assert lines == ['   col0   ',
                          'int64[2,2]',
                          '----------',
@@ -73,7 +73,7 @@ class TestMultiD():
                np.array([[(5,)],
                          [(50,)]], dtype=np.int64)]
         t = table_type(arr)
-        lines = t.pformat()
+        lines = t.pformat(show_dtype=True)
         assert lines == [
             "   col0       col1       col2   ",
             "int64[1,1] int64[1,1] int64[1,1]",
@@ -81,7 +81,7 @@ class TestMultiD():
             "         1          3          5",
             "        10         30         50"]
 
-        lines = t.pformat(html=True)
+        lines = t.pformat(html=True, show_dtype=True)
         assert lines == [
             f'<table id="table{id(t)}">',
             '<thead><tr><th>col0</th><th>col1</th><th>col2</th></tr></thead>',
@@ -101,7 +101,7 @@ class TestMultiD():
             '</table></div>']
 
         t = table_type([arr])
-        lines = t.pformat()
+        lines = t.pformat(show_dtype=True)
         assert lines == ['    col0    ',
                          'int64[2,1,1]',
                          '------------',
@@ -391,11 +391,9 @@ class TestFormat():
         # mathematical function
         t['a'].format = lambda x: str(x * 3.)
         outstr = ('     a      \n'
-                  '  int64[2]  \n'
                   '------------\n'
                   '  3.0 .. 6.0\n'
                   '30.0 .. 60.0')
-        assert str(t['a']) == outstr
         assert str(t['a']) == outstr
 
     def test_column_format_func_not_str(self, table_type):
@@ -542,7 +540,6 @@ class TestFormatWithMaskedElements():
         # mathematical function
         t['a'].format = lambda x: str(x * 3.)
         outstr = ('    a     \n'
-                  ' int64[2] \n'
                   '----------\n'
                   ' 3.0 .. --\n'
                   '30.0 .. --')

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -107,7 +107,6 @@ def test_votable(capsys):
     out, err = capsys.readouterr()
     assert out.splitlines() == [
         '   string_test    string_test_2 ...   bitarray2  ',
-        '      object          str10     ...    bool[16]  ',
         '----------------- ------------- ... -------------',
         '    String & test    Fixed stri ... True .. False',
         'String &amp; test    0123456789 ...      -- .. --',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to revert the change of `show_dtype=False` to `show_dtype=None` in #12644.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### Checklist for package maintainer(s)
<!-- This section is to be filled by package maintainer(s) who will
review this pull request. -->

This checklist is meant to remind the package maintainer(s) who will review this pull request of some common things to look for. This list is not exhaustive.

- [ ] Do the proposed changes actually accomplish desired goals?
- [ ] Do the proposed changes follow the [Astropy coding guidelines](https://docs.astropy.org/en/latest/development/codeguide.html)?
- [ ] Are tests added/updated as required? If so, do they follow the [Astropy testing guidelines](https://docs.astropy.org/en/latest/development/testguide.html)?
- [ ] Are docs added/updated as required? If so, do they follow the [Astropy documentation guidelines](https://docs.astropy.org/en/latest/development/docguide.html#astropy-documentation-rules-and-guidelines)?
- [ ] Is rebase and/or squash necessary? If so, please provide the author with appropriate instructions. Also see ["When to rebase and squash commits"](https://docs.astropy.org/en/latest/development/when_to_rebase.html).
- [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the `Extra CI` label.
- [ ] Is a change log needed? If yes, did the change log check pass? If no, add the `no-changelog-entry-needed` label. If this is a manual backport, use the `skip-changelog-checks` label unless special changelog handling is necessary.
- [ ] Is a milestone set? Milestone must be set but `astropy-bot` check might be missing; do not let the green checkmark fool you.
- [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate `backport-X.Y.x` label(s) *before* merge.
